### PR TITLE
Fix unbounded 429 retry recursion in base client

### DIFF
--- a/src/wealthbox_tools/client/base.py
+++ b/src/wealthbox_tools/client/base.py
@@ -90,6 +90,7 @@ class _WealthboxBase:
         token: str | None = None,
         base_url: str = BASE_URL,
         rate_limit: bool = True,
+        max_429_retries: int = 5,
     ):
         self._token = token or os.environ.get("WEALTHBOX_TOKEN", "")
         if not self._token:
@@ -97,6 +98,7 @@ class _WealthboxBase:
                 "Wealthbox token required. Pass token= or set WEALTHBOX_TOKEN env var."
             )
         self._rate_limiter = RateLimiter() if rate_limit else None
+        self._max_429_retries = max_429_retries
         self._http = httpx.AsyncClient(
             base_url=base_url,
             headers={"ACCESS_TOKEN": self._token},
@@ -114,15 +116,30 @@ class _WealthboxBase:
         if self._rate_limiter:
             await self._rate_limiter.acquire()
 
-        try:
-            response = await self._http.request(method, path, params=params, json=json)
-        except httpx.RequestError as exc:
-            raise WealthboxAPIError(0, f"Request failed: {exc}", exc.request) from exc  # type: ignore[arg-type]
+        retries = 0
+        while True:
+            try:
+                response = await self._http.request(method, path, params=params, json=json)
+            except httpx.RequestError as exc:
+                raise WealthboxAPIError(0, f"Request failed: {exc}", exc.request) from exc  # type: ignore[arg-type]
 
-        if response.status_code == 429:
-            retry_after = float(response.headers.get("Retry-After", "5"))
-            await asyncio.sleep(retry_after)
-            return await self._request(method, path, params=params, json=json)
+            if response.status_code != 429:
+                break
+
+            retries += 1
+            if retries > self._max_429_retries:
+                raise WealthboxAPIError(
+                    429,
+                    f"Rate limited after {self._max_429_retries} retries.",
+                    response,
+                )
+
+            try:
+                retry_after = float(response.headers.get("Retry-After", "5"))
+            except ValueError:
+                retry_after = 5.0
+
+            await asyncio.sleep(max(retry_after, 0.0))
 
         if response.is_error:
             try:

--- a/tests/test_base_client.py
+++ b/tests/test_base_client.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from wealthbox_tools.client.base import _WealthboxBase, WealthboxAPIError
+
+
+@pytest.mark.asyncio
+async def test_request_429_retries_and_succeeds(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = {"count": 0}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        calls["count"] += 1
+        if calls["count"] < 3:
+            return httpx.Response(429, headers={"Retry-After": "0"})
+        return httpx.Response(200, json={"ok": True})
+
+    client = _WealthboxBase(token="test-token", rate_limit=False, max_429_retries=5)
+    client._http = httpx.AsyncClient(transport=httpx.MockTransport(handler), base_url="https://api.crmworkspace.com/v1")
+
+    sleep_calls: list[float] = []
+
+    async def fake_sleep(delay: float) -> None:
+        sleep_calls.append(delay)
+
+    monkeypatch.setattr("wealthbox_tools.client.base.asyncio.sleep", fake_sleep)
+
+    response = await client._request("GET", "/tasks")
+    assert response.status_code == 200
+    assert calls["count"] == 3
+    assert sleep_calls == [0.0, 0.0]
+
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_request_429_invalid_retry_after_uses_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = {"count": 0}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        calls["count"] += 1
+        if calls["count"] == 1:
+            return httpx.Response(429, headers={"Retry-After": "not-a-number"})
+        return httpx.Response(200, json={"ok": True})
+
+    client = _WealthboxBase(token="test-token", rate_limit=False, max_429_retries=3)
+    client._http = httpx.AsyncClient(transport=httpx.MockTransport(handler), base_url="https://api.crmworkspace.com/v1")
+
+    sleep_calls: list[float] = []
+
+    async def fake_sleep(delay: float) -> None:
+        sleep_calls.append(delay)
+
+    monkeypatch.setattr("wealthbox_tools.client.base.asyncio.sleep", fake_sleep)
+
+    response = await client._request("GET", "/tasks")
+    assert response.status_code == 200
+    assert sleep_calls == [5.0]
+
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_request_429_exceeds_retry_limit() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(429, headers={"Retry-After": "0"})
+
+    client = _WealthboxBase(token="test-token", rate_limit=False, max_429_retries=2)
+    client._http = httpx.AsyncClient(transport=httpx.MockTransport(handler), base_url="https://api.crmworkspace.com/v1")
+
+    with pytest.raises(WealthboxAPIError, match="Rate limited after 2 retries"):
+        await client._request("GET", "/tasks")
+
+    await client.aclose()


### PR DESCRIPTION
### Motivation
- The base HTTP client recursed on HTTP 429 responses which can cause unbounded recursion/stack growth under sustained rate limiting.  
- The `Retry-After` header handling could raise on malformed values and did not guard against negative values.  
- The client should expose a configurable, bounded retry policy so callers can control behavior under rate limiting.

### Description
- Refactored `_WealthboxBase._request` to use an iterative retry loop for `429` responses and added a constructor option `max_429_retries` (default `5`).  
- When the retry cap is exceeded the client now raises a clear `WealthboxAPIError` indicating rate limit exhaustion.  
- Hardened `Retry-After` parsing to fall back to `5.0` seconds on malformed values and clamp negative waits to `0.0` before sleeping.  
- Added focused async unit tests in `tests/test_base_client.py` covering transient `429` retries, malformed `Retry-After` fallback, and retry-limit exhaustion; modified file `src/wealthbox_tools/client/base.py` accordingly.

### Testing
- Ran the full test suite with `pytest -q`, which failed during collection due to missing dev dependency `respx` (ModuleNotFoundError) and import path issues in this environment.  
- Attempted to install `respx` but network/proxy restrictions prevented installation.  
- Ran the new targeted tests with `PYTHONPATH=src pytest -q tests/test_base_client.py`, which could not complete because the runtime here is Python 3.10 and the codebase imports `enum.StrEnum` (Python 3.11+), causing an `ImportError` during collection; the added tests themselves exercise the new retry logic and are expected to pass in a compatible environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b2d66e48bc832899ec011ec9ef1958)