### PR TITLE
v1.1.1: wbox skills sync + skill doc improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,8 +124,11 @@ This updates the generated half of the skill's firm files; hand-edited policy is
 ```bash
 wbox skills list             # show where the skill is installed + last bootstrap time
 wbox skills doctor           # diagnose install state + token
+wbox skills sync             # copy firm/ from one install to others (Claude Code <-> Codex)
 wbox skills uninstall        # remove the skill
 ```
+
+`wbox skills sync` is useful if you maintain firm conventions in one platform's install (e.g., your Claude Code user scope) and want the same `firm/` files mirrored to Codex or to a project-scoped `.claude/skills/` folder. The command runs as a wizard by default; pass `--source`, `--target`, and `--yes` for non-interactive use.
 
 ### Works with other agents too
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wealthbox-cli"
-version = "1.1.0"
+version = "1.1.1"
 description = "CLI and client library for the Wealthbox CRM API"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/wealthbox_tools/cli/skills.py
+++ b/src/wealthbox_tools/cli/skills.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import shutil
 from datetime import datetime, timezone
 from importlib.resources import as_file, files
 from pathlib import Path
@@ -241,6 +242,142 @@ def doctor_cmd(
         typer.echo(f"  token failed: {e}")
     except Exception as e:  # network, config, etc.
         typer.echo(f"  token check failed: {e}")
+
+
+def _prompt_sync_source(installed: list[Platform]) -> Platform:
+    typer.echo("Installed platforms:")
+    for i, p in enumerate(installed, 1):
+        typer.echo(f"  {i}. {p.id:<22} {p.label}")
+    while True:
+        raw = typer.prompt("Source platform (id or number)").strip()
+        for i, p in enumerate(installed, 1):
+            if raw == str(i) or raw == p.id:
+                return p
+        typer.echo(f"  ! unknown selection {raw!r}; try again", err=True)
+
+
+def _prompt_sync_targets(candidates: list[Platform]) -> list[Platform]:
+    typer.echo("Available targets:")
+    for i, p in enumerate(candidates, 1):
+        typer.echo(f"  {i}. {p.id:<22} {p.label}")
+    typer.echo("  a. all of the above")
+    raw = typer.prompt("Targets (comma-separated ids/numbers, or 'a')").strip()
+    if raw.lower() in {"a", "all"}:
+        return list(candidates)
+    selected: list[Platform] = []
+    for token in (t.strip() for t in raw.split(",") if t.strip()):
+        match: Platform | None = None
+        for i, p in enumerate(candidates, 1):
+            if token == str(i) or token == p.id:
+                match = p
+                break
+        if match is None:
+            raise typer.BadParameter(f"unknown target {token!r}")
+        if match not in selected:
+            selected.append(match)
+    return selected
+
+
+@app.command(
+    "sync",
+    help="Copy firm/ files from one installed platform to one or more others.",
+)
+def sync_cmd(
+    source_id: str | None = typer.Option(
+        None, "--source", "-s",
+        help="Platform id to copy firm/ from. Prompts if omitted.",
+    ),
+    target_ids: list[str] = typer.Option(
+        [], "--target", "-t",
+        help="Platform id to copy firm/ to. Repeat for multiple. Prompts if omitted.",
+    ),
+    all_targets: bool = typer.Option(
+        False, "--all-targets",
+        help="Sync to every installed platform except the source.",
+    ),
+    dry_run: bool = typer.Option(
+        False, "--dry-run", help="Show planned writes without copying.",
+    ),
+    yes: bool = typer.Option(
+        False, "--yes", "-y", help="Skip confirmation prompt.",
+    ),
+) -> None:
+    installed = [p for p in detect_platforms() if is_installed(p)]
+    if len(installed) < 2:
+        ids = [p.id for p in installed] or ["none"]
+        typer.echo(
+            f"Need at least two installed platforms to sync. Installed: {ids}",
+            err=True,
+        )
+        raise typer.Exit(code=2)
+
+    if source_id:
+        source = _resolve_platforms([source_id])[0]
+        if not is_installed(source):
+            typer.echo(f"Error: source {source.id!r} is not installed.", err=True)
+            raise typer.Exit(code=2)
+    else:
+        source = _prompt_sync_source(installed)
+
+    src_firm = skill_dir(source) / "firm"
+    if not src_firm.is_dir():
+        typer.echo(
+            f"Error: {source.id} has no firm/ directory at {src_firm}. "
+            f"Run 'wbox skills bootstrap --platform {source.id}' first.",
+            err=True,
+        )
+        raise typer.Exit(code=2)
+
+    others = [p for p in installed if p.id != source.id]
+
+    if all_targets and target_ids:
+        typer.echo("Error: --all-targets and --target are mutually exclusive.", err=True)
+        raise typer.Exit(code=2)
+
+    if all_targets:
+        targets = others
+    elif target_ids:
+        targets = _resolve_platforms(target_ids)
+        for t in targets:
+            if t.id == source.id:
+                typer.echo(f"Error: target {t.id!r} is the same as the source.", err=True)
+                raise typer.Exit(code=2)
+            if not is_installed(t):
+                typer.echo(f"Error: target {t.id!r} is not installed.", err=True)
+                raise typer.Exit(code=2)
+    else:
+        targets = _prompt_sync_targets(others)
+
+    if not targets:
+        typer.echo("No targets selected.", err=True)
+        raise typer.Exit(code=2)
+
+    typer.echo(f"Source: {source.id} ({src_firm})")
+    typer.echo("Targets:")
+    for t in targets:
+        typer.echo(f"  {t.id} ({skill_dir(t) / 'firm'})")
+
+    src_files = sorted(p for p in src_firm.rglob("*") if p.is_file())
+
+    if dry_run:
+        for t in targets:
+            tgt_firm = skill_dir(t) / "firm"
+            for src_file in src_files:
+                rel = src_file.relative_to(src_firm)
+                dest = tgt_firm / rel
+                action = "overwrite" if dest.exists() else "create"
+                typer.echo(f"  [dry-run][{t.id}] {action} firm/{rel.as_posix()}")
+        return
+
+    if not yes and not typer.confirm("Proceed with sync?", default=False):
+        typer.echo("Cancelled.")
+        raise typer.Exit(code=1)
+
+    for t in targets:
+        tgt_firm = skill_dir(t) / "firm"
+        tgt_firm.mkdir(parents=True, exist_ok=True)
+        shutil.copytree(src_firm, tgt_firm, dirs_exist_ok=True)
+        typer.echo(f"OK synced {len(src_files)} files: {source.id} -> {t.id}")
 
 
 @app.command("uninstall", help="Remove the wealthbox-crm skill from a platform.")

--- a/src/wealthbox_tools/skills/wealthbox-crm/SKILL.md
+++ b/src/wealthbox_tools/skills/wealthbox-crm/SKILL.md
@@ -68,10 +68,45 @@ When `firm/workflows.md` defines named workflows (e.g., "onboarding", "meeting f
 - If the user asks to "show" or "display", use `--format table`
 - If the user is piping or scripting, use `--format json`
 
+## Common Recipes
+
+**Find then act.** Almost every operation starts by resolving a name to an ID:
+
+```bash
+wbox contacts list --name "Smith" --type Household --format json
+# read the id from output, then:
+wbox notes add "Discussed Roth conversion." --contact <ID>
+```
+
+Use `--name` for contains-match name search (not `--search`). Combine with `--type` and `--contact-type` to narrow.
+
+**Multi-line content with shell-special characters.** The note/task body is a positional arg, so `$`, backticks, and `!` will be interpolated by bash. Three safe patterns:
+
+```bash
+# 1. Single quotes — no interpolation, simplest for one-liners
+wbox notes add 'Q1 distribution of $5,000 sent on 4/27.' --contact 123
+
+# 2. Heredoc via command substitution — best for multi-paragraph
+wbox notes add "$(cat <<'EOF'
+Subject: SS Analysis follow-up
+
+Sent the MaxiFi report on 4/27. Awaiting reply.
+Strategy: defer to age 70, ~$48,000/yr.
+EOF
+)" --contact 123
+
+# 3. Read from a file
+wbox notes add "$(cat /tmp/note.md)" --contact 123
+```
+
+The single-quoted heredoc (`<<'EOF'`) is the recommended default — it disables all bash expansion inside the body.
+
 ## Patterns to Know
 
 - **ID shorthand:** `wbox contacts 123` is the same as `wbox contacts get 123`
 - **Linking:** most resources accept `--contact ID`, `--project ID`, `--opportunity ID`
 - **More fields:** `--more-fields '{"key": "value"}'` for fields without dedicated flags
 - **Dates:** use `YYYY-MM-DD` for dates, `YYYY-MM-DDTHH:MM:SS-07:00` for datetimes
+- **Relative due dates:** tasks accept `--frame today|tomorrow|this-week|next-week|this-month|next-month` instead of `--due-date` (mutually exclusive)
 - **Activity pagination:** uses `--cursor`, not `--page`
+- **Don't infer flag names:** read `references/<resource>.md` before invoking — flags like `--name` (not `--search`), `--frame` (not `--due-in`) are easy to guess wrong

--- a/src/wealthbox_tools/skills/wealthbox-crm/references/notes.md
+++ b/src/wealthbox_tools/skills/wealthbox-crm/references/notes.md
@@ -1,6 +1,6 @@
 # Notes
 
-Notes attach free-text content to contacts, projects, or opportunities. No delete support in the API.
+Notes attach free-text content to contacts, projects, or opportunities. No delete support in the API. Text-only — file attachments must be added via the Wealthbox web UI.
 
 ## List Notes
 

--- a/tests/test_skills_cli_sync.py
+++ b/tests/test_skills_cli_sync.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from wealthbox_tools.cli.main import app
+
+
+def _setup(runner, tmp_path, monkeypatch, *platforms: str) -> tuple[Path, Path]:
+    """Install one or more platforms in isolated HOME / cwd dirs."""
+    home = tmp_path / "home"
+    project = tmp_path / "project"
+    home.mkdir(exist_ok=True)
+    project.mkdir(exist_ok=True)
+    (project / ".git").mkdir(exist_ok=True)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+    monkeypatch.chdir(project)
+    for plat in platforms:
+        result = runner.invoke(
+            app, ["skills", "install", "--platform", plat, "--no-bootstrap"]
+        )
+        assert result.exit_code == 0, result.stdout
+    return home, project
+
+
+def _firm_dir(home: Path, project: Path, platform_id: str) -> Path:
+    if platform_id == "codex":
+        return home / ".codex" / "skills" / "wealthbox-crm" / "firm"
+    if platform_id == "claude-code-user":
+        return home / ".claude" / "skills" / "wealthbox-crm" / "firm"
+    if platform_id == "claude-code-project":
+        return project / ".claude" / "skills" / "wealthbox-crm" / "firm"
+    raise ValueError(platform_id)
+
+
+def test_sync_copies_firm_dir(runner, tmp_path, monkeypatch):
+    home, project = _setup(runner, tmp_path, monkeypatch, "codex", "claude-code-project")
+
+    src_firm = _firm_dir(home, project, "codex")
+    src_firm.mkdir(parents=True, exist_ok=True)
+    (src_firm / "notes.md").write_text("FIRM NOTES SYNCED")
+    (src_firm / "_meta.json").write_text('{"firm": {"name": "Acme"}}')
+
+    result = runner.invoke(
+        app,
+        ["skills", "sync", "-s", "codex", "-t", "claude-code-project", "--yes"],
+    )
+    assert result.exit_code == 0, result.stdout + (result.stderr or "")
+
+    tgt = _firm_dir(home, project, "claude-code-project")
+    assert (tgt / "notes.md").read_text() == "FIRM NOTES SYNCED"
+    assert (tgt / "_meta.json").exists()
+
+
+def test_sync_dry_run_does_not_write(runner, tmp_path, monkeypatch):
+    home, project = _setup(runner, tmp_path, monkeypatch, "codex", "claude-code-project")
+    src_firm = _firm_dir(home, project, "codex")
+    src_firm.mkdir(parents=True, exist_ok=True)
+    (src_firm / "notes.md").write_text("SHOULD NOT WRITE")
+
+    result = runner.invoke(
+        app,
+        ["skills", "sync", "-s", "codex", "-t", "claude-code-project", "--dry-run"],
+    )
+    assert result.exit_code == 0, result.stdout
+    assert "dry-run" in result.stdout
+    tgt = _firm_dir(home, project, "claude-code-project")
+    assert not (tgt / "notes.md").exists()
+
+
+def test_sync_errors_when_source_has_no_firm(runner, tmp_path, monkeypatch):
+    _setup(runner, tmp_path, monkeypatch, "codex", "claude-code-project")
+    # Don't create firm/ in source
+    result = runner.invoke(
+        app,
+        ["skills", "sync", "-s", "codex", "-t", "claude-code-project", "--yes"],
+    )
+    assert result.exit_code != 0
+    output = (result.stdout or "") + (result.stderr or "")
+    assert "no firm/" in output.lower()
+
+
+def test_sync_errors_when_source_equals_target(runner, tmp_path, monkeypatch):
+    home, project = _setup(runner, tmp_path, monkeypatch, "codex", "claude-code-project")
+    src_firm = _firm_dir(home, project, "codex")
+    src_firm.mkdir(parents=True, exist_ok=True)
+    (src_firm / "notes.md").write_text("hi")
+
+    result = runner.invoke(
+        app,
+        ["skills", "sync", "-s", "codex", "-t", "codex", "--yes"],
+    )
+    assert result.exit_code != 0
+    output = (result.stdout or "") + (result.stderr or "")
+    assert "same as the source" in output.lower()
+
+
+def test_sync_errors_when_only_one_platform_installed(runner, tmp_path, monkeypatch):
+    _setup(runner, tmp_path, monkeypatch, "codex")
+    result = runner.invoke(
+        app,
+        ["skills", "sync", "-s", "codex", "-t", "claude-code-project", "--yes"],
+    )
+    assert result.exit_code != 0
+    output = (result.stdout or "") + (result.stderr or "")
+    assert "at least two" in output.lower()
+
+
+def test_sync_all_targets_fans_out(runner, tmp_path, monkeypatch):
+    home, project = _setup(
+        runner, tmp_path, monkeypatch,
+        "codex", "claude-code-user", "claude-code-project",
+    )
+    src_firm = _firm_dir(home, project, "codex")
+    src_firm.mkdir(parents=True, exist_ok=True)
+    (src_firm / "notes.md").write_text("FANNED OUT")
+
+    result = runner.invoke(
+        app,
+        ["skills", "sync", "-s", "codex", "--all-targets", "--yes"],
+    )
+    assert result.exit_code == 0, result.stdout + (result.stderr or "")
+
+    user_target = _firm_dir(home, project, "claude-code-user")
+    project_target = _firm_dir(home, project, "claude-code-project")
+    assert (user_target / "notes.md").read_text() == "FANNED OUT"
+    assert (project_target / "notes.md").read_text() == "FANNED OUT"
+
+
+def test_sync_rejects_all_targets_with_explicit_target(runner, tmp_path, monkeypatch):
+    home, project = _setup(runner, tmp_path, monkeypatch, "codex", "claude-code-project")
+    src_firm = _firm_dir(home, project, "codex")
+    src_firm.mkdir(parents=True, exist_ok=True)
+    (src_firm / "notes.md").write_text("hi")
+
+    result = runner.invoke(
+        app,
+        [
+            "skills", "sync",
+            "-s", "codex",
+            "-t", "claude-code-project",
+            "--all-targets",
+            "--yes",
+        ],
+    )
+    assert result.exit_code != 0
+    output = (result.stdout or "") + (result.stderr or "")
+    assert "mutually exclusive" in output.lower()


### PR DESCRIPTION
## Summary

- Add `wbox skills sync` — copies `firm/` files from one installed platform to one or more others, with wizard-style prompts by default and `--source` / `--target` / `--all-targets` / `--dry-run` / `--yes` flags for non-interactive use. Closes #4.
- Roll up SKILL.md / `references/notes.md` improvements from a real-world usage review: new "Common Recipes" section (find-then-act, multi-line content with shell-special characters), `--frame` and "don't infer flag names" surfaced in Patterns to Know, and a one-line note that attachments are web-UI only.
- Bump to 1.1.1.

## Test plan

- [x] `ruff check src/ tests/` clean
- [x] `pytest` — 203 passed (including 7 new tests in `test_skills_cli_sync.py`)
- [x] `wbox --version` reports `1.1.1`
- [x] `wbox skills sync -h` renders the new command
- [ ] Manual smoke test: install to two platforms, edit `firm/notes.md` in source, run `wbox skills sync` interactively, confirm target reflects source

🤖 Generated with [Claude Code](https://claude.com/claude-code)