### PR TITLE
v1.1.2: wbox skills upgrade + _meta.json schema move

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,8 +125,11 @@ This updates the generated half of the skill's firm files; hand-edited policy is
 wbox skills list             # show where the skill is installed + last bootstrap time
 wbox skills doctor           # diagnose install state + token
 wbox skills sync             # copy firm/ from one install to others (Claude Code <-> Codex)
+wbox skills upgrade          # refresh template files (SKILL.md, references/, ...) preserving firm/
 wbox skills uninstall        # remove the skill
 ```
+
+When the CLI ships a newer template (improved SKILL.md, new reference docs, etc.), `wbox skills upgrade` re-copies the bundled template into every installed platform without touching your firm-specific data in `firm/`. Each install records the template's CLI version in `_meta.json`, so the agent can detect drift and prompt you to upgrade when needed.
 
 `wbox skills sync` is useful if you maintain firm conventions in one platform's install (e.g., your Claude Code user scope) and want the same `firm/` files mirrored to Codex or to a project-scoped `.claude/skills/` folder. The command runs as a wizard by default; pass `--source`, `--target`, and `--yes` for non-interactive use.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wealthbox-cli"
-version = "1.1.1"
+version = "1.1.2"
 description = "CLI and client library for the Wealthbox CRM API"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/wealthbox_tools/cli/_skill_bootstrap.py
+++ b/src/wealthbox_tools/cli/_skill_bootstrap.py
@@ -86,11 +86,11 @@ def render_users_md(users: list[dict[str, Any]]) -> str:
 FIRM_README = """# firm/ — Firm Customizations
 
 This folder holds everything the agent needs to know about your firm's
-Wealthbox conventions.
+Wealthbox conventions. Install metadata lives in `../_meta.json` (skill
+root), not here.
 
 ## Generated files (overwritten by `wbox skills refresh`)
 
-- `_meta.json` — refresh timestamps, firm identity, CLI version
 - `categories.md` — every category type + valid values
 - `custom-fields.md` — custom fields per document type + valid values
 - `users.md` — user id → name → email
@@ -139,22 +139,52 @@ def write_stubs(firm_dir: Path) -> list[str]:
     return written
 
 
-def write_meta_json(
-    firm_dir: Path,
+def meta_path(skill_dir: Path) -> Path:
+    """Location of _meta.json relative to a skill install root."""
+    return skill_dir / "_meta.json"
+
+
+def read_meta(skill_dir: Path) -> dict[str, Any]:
+    """Read _meta.json. Returns {} if missing or unreadable."""
+    p = meta_path(skill_dir)
+    if not p.exists():
+        return {}
+    try:
+        loaded = json.loads(p.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return {}
+    return loaded if isinstance(loaded, dict) else {}
+
+
+def write_meta(skill_dir: Path, data: dict[str, Any]) -> None:
+    meta_path(skill_dir).write_text(
+        json.dumps(data, indent=2) + "\n", encoding="utf-8"
+    )
+
+
+def update_template_meta(skill_dir: Path, *, cli_version: str) -> None:
+    """Set the template section of _meta.json. Preserves any existing firm section."""
+    meta = read_meta(skill_dir)
+    meta["template"] = {"cli_version": cli_version}
+    write_meta(skill_dir, meta)
+
+
+def update_firm_meta(
+    skill_dir: Path,
     *,
-    generated_files: list[str],
-    firm_identity: dict[str, Any],
+    identity: dict[str, Any],
     cli_version: str,
+    generated_files: list[str],
 ) -> None:
+    """Set the firm section of _meta.json. Preserves any existing template section."""
     now = datetime.now(timezone.utc).isoformat()
-    meta = {
-        "firm": firm_identity,
+    meta = read_meta(skill_dir)
+    meta["firm"] = {
+        "identity": identity,
         "cli_version": cli_version,
         "files": {name: now for name in generated_files},
     }
-    (firm_dir / "_meta.json").write_text(
-        json.dumps(meta, indent=2) + "\n", encoding="utf-8"
-    )
+    write_meta(skill_dir, meta)
 
 
 # --------------------------------------------------------------------------- #
@@ -230,11 +260,11 @@ def bootstrap_skill_dir(
     (firm_dir / "users.md").write_text(render_users_md(users), encoding="utf-8")
 
     generated = ["categories.md", "custom-fields.md", "users.md"]
-    write_meta_json(
-        firm_dir,
-        generated_files=generated,
-        firm_identity=firm_identity,
+    update_firm_meta(
+        skill_dir,
+        identity=firm_identity,
         cli_version=_pkg_version("wealthbox-cli"),
+        generated_files=generated,
     )
 
     wrote_stubs = 0

--- a/src/wealthbox_tools/cli/_skill_platforms.py
+++ b/src/wealthbox_tools/cli/_skill_platforms.py
@@ -69,10 +69,36 @@ def install_skill(platform: Platform, src: Path, *, force: bool) -> None:
         _safe_rmtree(platform, dest)
     dest.parent.mkdir(parents=True, exist_ok=True)
     shutil.copytree(src, dest)
-    if platform.skill_filename != "SKILL.md":
-        skill_md = dest / "SKILL.md"
-        if skill_md.exists():
-            skill_md.rename(dest / platform.skill_filename)
+    _rename_skill_md(platform, dest)
+
+
+def upgrade_skill(platform: Platform, src: Path) -> None:
+    """Re-copy the bundled template over an existing install.
+
+    Preserves the user's `firm/` directory and root `_meta.json` (the
+    bundled template ships neither). Refreshes SKILL.md, references/,
+    firm-examples/, and bootstrap.md.
+    """
+    dest = skill_dir(platform)
+    if not dest.is_dir() or not (dest / platform.skill_filename).is_file():
+        raise SkillInstallError(
+            f"Cannot upgrade: nothing installed at {dest}"
+        )
+    shutil.copytree(src, dest, dirs_exist_ok=True)
+    _rename_skill_md(platform, dest)
+
+
+def _rename_skill_md(platform: Platform, dest: Path) -> None:
+    """Rename SKILL.md → platform.skill_filename if needed (e.g. AGENTS.md for codex)."""
+    if platform.skill_filename == "SKILL.md":
+        return
+    skill_md = dest / "SKILL.md"
+    target = dest / platform.skill_filename
+    if not skill_md.exists():
+        return
+    if target.exists():
+        target.unlink()
+    skill_md.rename(target)
 
 
 def uninstall_skill(platform: Platform) -> None:

--- a/src/wealthbox_tools/cli/skills.py
+++ b/src/wealthbox_tools/cli/skills.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
-import json
 import shutil
 from datetime import datetime, timezone
+from importlib.metadata import version as _pkg_version
 from importlib.resources import as_file, files
 from pathlib import Path
 
 import typer
 
+from ._skill_bootstrap import read_meta, update_template_meta
 from ._skill_platforms import (
     Platform,
     SkillInstallError,
@@ -16,6 +17,7 @@ from ._skill_platforms import (
     is_installed,
     skill_dir,
     uninstall_skill,
+    upgrade_skill,
 )
 
 app = typer.Typer(
@@ -27,31 +29,31 @@ app = typer.Typer(
 
 @app.command("list", help="Show where the skill is installed per platform.")
 def list_platforms() -> None:
-    header = ("platform", "path", "status", "last-bootstrap")
-    rows: list[tuple[str, str, str, str]] = []
+    header = ("platform", "path", "status", "template-version", "last-bootstrap")
+    rows: list[tuple[str, str, str, str, str]] = []
     for p in detect_platforms():
         dest = skill_dir(p)
         installed = is_installed(p)
-        meta_file = dest / "firm" / "_meta.json"
+        template_version = "-"
         last_bootstrap = "-"
-        if meta_file.exists():
-            try:
-                meta = json.loads(meta_file.read_text())
-                files = meta.get("files", {})
-                if files:
-                    last_bootstrap = max(files.values())
-            except (json.JSONDecodeError, OSError):
-                last_bootstrap = "(unreadable)"
+        if installed:
+            meta = read_meta(dest)
+            template_version = meta.get("template", {}).get("cli_version", "-")
+            firm_section = meta.get("firm") or {}
+            firm_files = firm_section.get("files") or {}
+            if firm_files:
+                last_bootstrap = max(firm_files.values())
         rows.append((
             p.id,
             str(dest),
             "installed" if installed else "not installed",
+            template_version,
             last_bootstrap,
         ))
 
     widths = [
         max(len(r[i]) for r in ([header] + rows))
-        for i in range(4)
+        for i in range(len(header))
     ]
     fmt = "  ".join(f"{{:<{w}}}" for w in widths)
     typer.echo(fmt.format(*header))
@@ -113,6 +115,7 @@ def install_cmd(
             except SkillInstallError as e:
                 typer.echo(f"Error installing to {target.id}: {e}", err=True)
                 raise typer.Exit(code=1) from e
+            update_template_meta(skill_dir(target), cli_version=_pkg_version("wealthbox-cli"))
             typer.echo(f"OK installed to {skill_dir(target)}")
 
     if not no_bootstrap:
@@ -192,24 +195,63 @@ def refresh_cmd(
         raise typer.Exit(code=2)
 
     for t in targets:
-        meta_path = skill_dir(t) / "firm" / "_meta.json"
-        if meta_path.exists():
+        meta = read_meta(skill_dir(t))
+        firm_files = (meta.get("firm") or {}).get("files") or {}
+        if firm_files:
             try:
-                meta = json.loads(meta_path.read_text())
-                ts_values = list(meta.get("files", {}).values())
-                if ts_values:
-                    oldest = min(datetime.fromisoformat(ts) for ts in ts_values)
-                    age_days = (datetime.now(timezone.utc) - oldest).days
-                    if age_days > staleness_days:
-                        typer.echo(
-                            f"! {t.id}: generated files were {age_days} days stale - refreshing now",
-                            err=True,
-                        )
-            except (json.JSONDecodeError, OSError, ValueError):
+                oldest = min(datetime.fromisoformat(ts) for ts in firm_files.values())
+                age_days = (datetime.now(timezone.utc) - oldest).days
+                if age_days > staleness_days:
+                    typer.echo(
+                        f"! {t.id}: generated files were {age_days} days stale - refreshing now",
+                        err=True,
+                    )
+            except ValueError:
                 pass
 
         bootstrap_skill_dir(skill_dir(t), token=token, generated_only=True)
         typer.echo(f"OK refreshed {t.id}")
+
+
+@app.command(
+    "upgrade",
+    help="Refresh template files (SKILL.md, references/, firm-examples/, bootstrap.md) "
+         "in every installed platform. Preserves firm/ and _meta.json firm section.",
+)
+def upgrade_cmd(
+    platforms_flag: list[str] = typer.Option(
+        [], "--platform", "-p",
+        help="Platform id. Default: every installed platform.",
+    ),
+) -> None:
+    if platforms_flag:
+        targets = _resolve_platforms(platforms_flag)
+        for t in targets:
+            if not is_installed(t):
+                typer.echo(f"Error: {t.id!r} is not installed.", err=True)
+                raise typer.Exit(code=2)
+    else:
+        targets = [p for p in detect_platforms() if is_installed(p)]
+
+    if not targets:
+        typer.echo(
+            "No installed platforms found. Run 'wbox skills install' first.",
+            err=True,
+        )
+        raise typer.Exit(code=2)
+
+    current = _pkg_version("wealthbox-cli")
+
+    with as_file(files("wealthbox_tools").joinpath("skills/wealthbox-crm")) as src:
+        for t in targets:
+            existing = (read_meta(skill_dir(t)).get("template") or {}).get("cli_version", "-")
+            try:
+                upgrade_skill(t, Path(src))
+            except SkillInstallError as e:
+                typer.echo(f"Error upgrading {t.id}: {e}", err=True)
+                raise typer.Exit(code=1) from e
+            update_template_meta(skill_dir(t), cli_version=current)
+            typer.echo(f"OK upgraded {t.id}: {existing} -> {current}")
 
 
 @app.command("doctor", help="Diagnose install state and token.")
@@ -220,13 +262,19 @@ def doctor_cmd(
 
     from ._util import run_client
 
+    current = _pkg_version("wealthbox-cli")
     typer.echo("# Skill install state")
     for p in detect_platforms():
         status = "installed" if is_installed(p) else "not installed"
-        meta_path = skill_dir(p) / "firm" / "_meta.json"
-        bootstrapped = "bootstrapped" if meta_path.exists() else "not bootstrapped"
+        meta = read_meta(skill_dir(p)) if is_installed(p) else {}
+        bootstrapped = "bootstrapped" if meta.get("firm") else "not bootstrapped"
+        template_v = (meta.get("template") or {}).get("cli_version", "-")
+        upgrade_hint = ""
+        if template_v not in ("-", current):
+            upgrade_hint = f"  [upgrade available: {template_v} -> {current}]"
         typer.echo(
-            f"  {p.id:<22} {status:<16} {bootstrapped:<18} {skill_dir(p)}"
+            f"  {p.id:<22} {status:<16} {bootstrapped:<18} "
+            f"template={template_v:<10} {skill_dir(p)}{upgrade_hint}"
         )
 
     typer.echo("\n# Token")

--- a/src/wealthbox_tools/skills/wealthbox-crm/SKILL.md
+++ b/src/wealthbox_tools/skills/wealthbox-crm/SKILL.md
@@ -8,14 +8,34 @@ description: Use when the user wants to interact with Wealthbox CRM — creating
 Execute Wealthbox CRM operations via the `wbox` CLI. Supports contacts, tasks, notes, events,
 opportunities, projects, workflows, households, and read-only lookups (categories, users, activity, me).
 
-## First Run (self-delete after completion)
+## First Run
 
-If `firm/_meta.json` does not exist in this skill's directory, this is the
-first invocation on this machine. Before handling the user's request:
+If `_meta.json` in this skill's directory does **not** contain a `firm`
+section, the firm has not been onboarded yet on this machine. Before
+handling the user's request:
 
 1. Read `bootstrap.md` in this skill's directory.
 2. Follow it end-to-end.
-3. When done, this section and `bootstrap.md` will have been deleted.
+3. The bootstrap will populate `_meta.json.firm` so this check passes
+   on subsequent runs.
+
+## Staleness Check
+
+`_meta.json.template.cli_version` records which `wbox` version installed
+the template files. Compare it to the running CLI version:
+
+```bash
+wbox --version
+```
+
+If the template version is older, suggest the user run:
+
+```bash
+wbox skills upgrade
+```
+
+This refreshes SKILL.md, references/, firm-examples/, and bootstrap.md
+across every installed platform while preserving `firm/`.
 
 ## Prerequisites
 

--- a/src/wealthbox_tools/skills/wealthbox-crm/bootstrap.md
+++ b/src/wealthbox_tools/skills/wealthbox-crm/bootstrap.md
@@ -1,8 +1,7 @@
 # First-Run Bootstrap
 
-You were told to read this because `firm/_meta.json` does not exist in the skill
-directory. Follow every step below. When you finish, delete this file and trim
-the `## First Run` section out of `SKILL.md`.
+You were told to read this because `_meta.json` in the skill root does not
+contain a `firm` section. Follow every step below.
 
 ## Step 1 — Fetch API-derived firm data
 
@@ -17,12 +16,13 @@ It populates these files per installed platform:
 - `firm/categories.md` — every category type + valid values
 - `firm/custom-fields.md` — custom fields per document type + valid values
 - `firm/users.md` — user id → name → email
-- `firm/_meta.json` — refresh timestamps + firm identity
+- `_meta.json` (skill root) — adds the `firm` section: identity, refresh
+  timestamps, and the CLI version that ran the bootstrap
 - Stub files: `firm/contacts.md`, `firm/tasks.md`, `firm/notes.md`,
   `firm/events.md`, `firm/opportunities.md`, `firm/projects.md`,
   `firm/workflows.md` — one-line TODOs you will fill in next.
 
-Verify `firm/_meta.json` now exists before continuing.
+Verify the `firm` section now exists in `_meta.json` before continuing.
 
 ## Step 2 — Gather firm policy (per-resource)
 
@@ -90,16 +90,11 @@ Ask the advisor: "Is there any firm convention, custom process, or preference
 I haven't asked about that I should follow?" Append freeform answers to
 `firm/workflows.md` under a `## Other Conventions` heading.
 
-## Step 4 — Self-trim
-
-Now that all firm files are filled in:
-
-1. Delete `bootstrap.md` (this file).
-2. Open `SKILL.md`. Find the `## First Run (self-delete after completion)`
-   section. Delete that heading and everything under it through (but not
-   including) the next `## ` heading.
-
-## Step 5 — Confirm and continue
+## Step 4 — Confirm and continue
 
 Tell the advisor: "First-run setup complete — `firm/` populated for <firm
 name>." Then return to the user's original request.
+
+You don't need to delete this file or trim `SKILL.md`. The first-run check
+keys on `_meta.json.firm`, which now exists, so the bootstrap path will be
+skipped on every subsequent invocation automatically.

--- a/tests/test_skill_bootstrap_orchestrate.py
+++ b/tests/test_skill_bootstrap_orchestrate.py
@@ -57,7 +57,8 @@ def test_bootstrap_writes_generated_and_stubs_first_time(tmp_path):
     assert (firm / "categories.md").exists()
     assert (firm / "custom-fields.md").exists()
     assert (firm / "users.md").exists()
-    assert (firm / "_meta.json").exists()
+    assert (skill_dir / "_meta.json").exists()
+    assert not (firm / "_meta.json").exists()
     assert (firm / "_README.md").exists()
     for n in (
         "contacts.md", "tasks.md", "notes.md", "events.md",
@@ -101,8 +102,11 @@ def test_bootstrap_records_firm_identity_in_meta(tmp_path):
 
     bootstrap_skill_dir(skill_dir, token="t", generated_only=False)
 
-    meta = json.loads((skill_dir / "firm" / "_meta.json").read_text())
-    assert meta["firm"]["id"] == 31965
-    assert meta["firm"]["name"] == "Squire Wealth Advisors"
-    assert meta["firm"]["user_id"] == 42
-    assert meta["firm"]["user_name"] == "Kadin"
+    meta = json.loads((skill_dir / "_meta.json").read_text())
+    identity = meta["firm"]["identity"]
+    assert identity["id"] == 31965
+    assert identity["name"] == "Squire Wealth Advisors"
+    assert identity["user_id"] == 42
+    assert identity["user_name"] == "Kadin"
+    assert "cli_version" in meta["firm"]
+    assert meta["firm"]["files"]  # at least one generated-file timestamp

--- a/tests/test_skill_bootstrap_render.py
+++ b/tests/test_skill_bootstrap_render.py
@@ -89,12 +89,12 @@ def test_render_users_empty_list():
 # Stubs + meta.json                                                            #
 # --------------------------------------------------------------------------- #
 
-import json  # noqa: E402
-
 from wealthbox_tools.cli._skill_bootstrap import (  # noqa: E402
     FIRM_README,
     STUB_CONTENTS,
-    write_meta_json,
+    read_meta,
+    update_firm_meta,
+    update_template_meta,
     write_stubs,
 )
 
@@ -129,21 +129,43 @@ def test_write_stubs_never_overwrites(tmp_path):
     assert "contacts.md" not in written
 
 
-def test_write_meta_json_records_timestamps(tmp_path):
-    firm = tmp_path / "firm"
-    firm.mkdir()
-    write_meta_json(
-        firm,
+def test_update_template_meta_writes_to_skill_root(tmp_path):
+    update_template_meta(tmp_path, cli_version="1.1.2")
+    meta = read_meta(tmp_path)
+    assert meta == {"template": {"cli_version": "1.1.2"}}
+    assert (tmp_path / "_meta.json").exists()
+
+
+def test_update_firm_meta_preserves_template_section(tmp_path):
+    update_template_meta(tmp_path, cli_version="1.1.2")
+    update_firm_meta(
+        tmp_path,
+        identity={"id": 99, "name": "Test Firm"},
+        cli_version="1.1.2",
         generated_files=["categories.md", "custom-fields.md", "users.md"],
-        firm_identity={"id": 99, "name": "Test Firm"},
-        cli_version="1.1.0",
     )
-    meta = json.loads((firm / "_meta.json").read_text())
-    assert meta["firm"]["id"] == 99
-    assert meta["cli_version"] == "1.1.0"
-    assert set(meta["files"]) == {"categories.md", "custom-fields.md", "users.md"}
-    for ts in meta["files"].values():
+    meta = read_meta(tmp_path)
+    assert meta["template"] == {"cli_version": "1.1.2"}
+    assert meta["firm"]["identity"] == {"id": 99, "name": "Test Firm"}
+    assert meta["firm"]["cli_version"] == "1.1.2"
+    assert set(meta["firm"]["files"]) == {
+        "categories.md", "custom-fields.md", "users.md",
+    }
+    for ts in meta["firm"]["files"].values():
         assert "T" in ts  # ISO 8601
+
+
+def test_update_template_meta_preserves_firm_section(tmp_path):
+    update_firm_meta(
+        tmp_path,
+        identity={"id": 1, "name": "Old"},
+        cli_version="1.1.0",
+        generated_files=["categories.md"],
+    )
+    update_template_meta(tmp_path, cli_version="1.1.2")
+    meta = read_meta(tmp_path)
+    assert meta["template"]["cli_version"] == "1.1.2"
+    assert meta["firm"]["identity"]["name"] == "Old"
 
 
 def test_firm_readme_constant_mentions_generated_and_hand_edited():

--- a/tests/test_skill_template_resource.py
+++ b/tests/test_skill_template_resource.py
@@ -47,9 +47,18 @@ def test_skill_md_has_first_run_section():
     resource = files("wealthbox_tools").joinpath("skills/wealthbox-crm/SKILL.md")
     with as_file(resource) as path:
         content = path.read_text(encoding="utf-8")
-    assert "## First Run (self-delete after completion)" in content
-    assert "firm/_meta.json" in content
+    assert "## First Run" in content
+    assert "_meta.json" in content
     assert "bootstrap.md" in content
+
+
+def test_skill_md_has_staleness_check_section():
+    resource = files("wealthbox_tools").joinpath("skills/wealthbox-crm/SKILL.md")
+    with as_file(resource) as path:
+        content = path.read_text(encoding="utf-8")
+    assert "## Staleness Check" in content
+    assert "wbox skills upgrade" in content
+    assert "template.cli_version" in content
 
 
 def test_skill_md_workflow_mentions_firm_folder():

--- a/tests/test_skills_cli_bootstrap.py
+++ b/tests/test_skills_cli_bootstrap.py
@@ -46,12 +46,16 @@ def test_bootstrap_writes_all_firm_files(runner, tmp_path, monkeypatch):
     _setup_api_mocks()
     result = runner.invoke(app, ["skills", "bootstrap"])
     assert result.exit_code == 0, result.stdout
-    firm = tmp_path / ".claude" / "skills" / "wealthbox-crm" / "firm"
+    skill_root = tmp_path / ".claude" / "skills" / "wealthbox-crm"
+    firm = skill_root / "firm"
     for name in (
-        "categories.md", "custom-fields.md", "users.md", "_meta.json",
+        "categories.md", "custom-fields.md", "users.md",
         "_README.md", "contacts.md", "tasks.md",
     ):
         assert (firm / name).exists(), f"missing {name}"
+    # _meta.json now lives at the skill root, not inside firm/
+    assert (skill_root / "_meta.json").exists()
+    assert not (firm / "_meta.json").exists()
 
 
 @respx.mock

--- a/tests/test_skills_cli_refresh.py
+++ b/tests/test_skills_cli_refresh.py
@@ -58,11 +58,12 @@ def test_refresh_preserves_handedited_files(runner, tmp_path, monkeypatch):
 @respx.mock
 def test_refresh_warns_when_meta_is_stale(runner, tmp_path, monkeypatch):
     _install_and_bootstrap(runner, tmp_path, monkeypatch)
-    firm = tmp_path / ".claude" / "skills" / "wealthbox-crm" / "firm"
-    meta = json.loads((firm / "_meta.json").read_text())
+    skill_root = tmp_path / ".claude" / "skills" / "wealthbox-crm"
+    meta_path = skill_root / "_meta.json"
+    meta = json.loads(meta_path.read_text())
     stale = (datetime.now(timezone.utc) - timedelta(days=60)).isoformat()
-    meta["files"] = {k: stale for k in meta["files"]}
-    (firm / "_meta.json").write_text(json.dumps(meta) + "\n")
+    meta["firm"]["files"] = {k: stale for k in meta["firm"]["files"]}
+    meta_path.write_text(json.dumps(meta) + "\n")
     result = runner.invoke(app, ["skills", "refresh", "--staleness-days", "30"])
     assert result.exit_code == 0, result.stdout
     output = (result.stdout or "") + (result.stderr or "")

--- a/tests/test_skills_cli_sync.py
+++ b/tests/test_skills_cli_sync.py
@@ -39,7 +39,7 @@ def test_sync_copies_firm_dir(runner, tmp_path, monkeypatch):
     src_firm = _firm_dir(home, project, "codex")
     src_firm.mkdir(parents=True, exist_ok=True)
     (src_firm / "notes.md").write_text("FIRM NOTES SYNCED")
-    (src_firm / "_meta.json").write_text('{"firm": {"name": "Acme"}}')
+    (src_firm / "categories.md").write_text("# generated categories\n")
 
     result = runner.invoke(
         app,
@@ -49,7 +49,7 @@ def test_sync_copies_firm_dir(runner, tmp_path, monkeypatch):
 
     tgt = _firm_dir(home, project, "claude-code-project")
     assert (tgt / "notes.md").read_text() == "FIRM NOTES SYNCED"
-    assert (tgt / "_meta.json").exists()
+    assert (tgt / "categories.md").exists()
 
 
 def test_sync_dry_run_does_not_write(runner, tmp_path, monkeypatch):

--- a/tests/test_skills_cli_upgrade.py
+++ b/tests/test_skills_cli_upgrade.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from wealthbox_tools.cli.main import app
+
+
+def _install(runner, tmp_path, monkeypatch, platform: str = "claude-code-user") -> Path:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(
+        app, ["skills", "install", "--platform", platform, "--no-bootstrap"]
+    )
+    assert result.exit_code == 0, result.stdout
+    if platform == "codex":
+        return tmp_path / ".codex" / "skills" / "wealthbox-crm"
+    return tmp_path / ".claude" / "skills" / "wealthbox-crm"
+
+
+def test_upgrade_refreshes_template_files(runner, tmp_path, monkeypatch):
+    dest = _install(runner, tmp_path, monkeypatch)
+    (dest / "SKILL.md").write_text("TAMPERED")
+
+    result = runner.invoke(app, ["skills", "upgrade"])
+    assert result.exit_code == 0, result.stdout
+    assert (dest / "SKILL.md").read_text().startswith("---")  # frontmatter restored
+
+
+def test_upgrade_preserves_firm_directory(runner, tmp_path, monkeypatch):
+    dest = _install(runner, tmp_path, monkeypatch)
+    firm = dest / "firm"
+    firm.mkdir(exist_ok=True)
+    (firm / "contacts.md").write_text("MY POLICY\n")
+    (firm / "categories.md").write_text("# generated\n")
+
+    result = runner.invoke(app, ["skills", "upgrade"])
+    assert result.exit_code == 0, result.stdout
+    assert (firm / "contacts.md").read_text() == "MY POLICY\n"
+    assert (firm / "categories.md").read_text() == "# generated\n"
+
+
+def test_upgrade_preserves_firm_meta_section(runner, tmp_path, monkeypatch):
+    dest = _install(runner, tmp_path, monkeypatch)
+    # Simulate bootstrap having written a firm section
+    meta = json.loads((dest / "_meta.json").read_text())
+    meta["firm"] = {
+        "identity": {"id": 99, "name": "Test Firm"},
+        "cli_version": "1.1.1",
+        "files": {"categories.md": "2026-04-30T00:00:00+00:00"},
+    }
+    (dest / "_meta.json").write_text(json.dumps(meta) + "\n")
+
+    result = runner.invoke(app, ["skills", "upgrade"])
+    assert result.exit_code == 0, result.stdout
+    after = json.loads((dest / "_meta.json").read_text())
+    assert after["firm"]["identity"] == {"id": 99, "name": "Test Firm"}
+    assert after["firm"]["cli_version"] == "1.1.1"
+
+
+def test_upgrade_updates_template_cli_version(runner, tmp_path, monkeypatch):
+    dest = _install(runner, tmp_path, monkeypatch)
+    # Pretend an older version installed the template
+    meta = json.loads((dest / "_meta.json").read_text())
+    meta["template"]["cli_version"] = "1.0.0"
+    (dest / "_meta.json").write_text(json.dumps(meta) + "\n")
+
+    result = runner.invoke(app, ["skills", "upgrade"])
+    assert result.exit_code == 0, result.stdout
+    after = json.loads((dest / "_meta.json").read_text())
+    assert after["template"]["cli_version"] != "1.0.0"
+    # Output reports the version transition
+    assert "1.0.0 ->" in result.stdout
+
+
+def test_upgrade_errors_when_nothing_installed(runner, tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["skills", "upgrade"])
+    assert result.exit_code != 0
+    output = (result.stdout or "") + (result.stderr or "")
+    assert "no installed" in output.lower()
+
+
+def test_upgrade_codex_keeps_agents_md_and_no_skill_md(runner, tmp_path, monkeypatch):
+    dest = _install(runner, tmp_path, monkeypatch, platform="codex")
+    assert (dest / "AGENTS.md").exists()
+    assert not (dest / "SKILL.md").exists()
+    (dest / "AGENTS.md").write_text("TAMPERED")
+
+    result = runner.invoke(app, ["skills", "upgrade"])
+    assert result.exit_code == 0, result.stdout
+    assert (dest / "AGENTS.md").read_text().startswith("---")
+    assert not (dest / "SKILL.md").exists()
+
+
+def test_upgrade_explicit_platform_flag(runner, tmp_path, monkeypatch):
+    dest = _install(runner, tmp_path, monkeypatch)
+    (dest / "SKILL.md").write_text("TAMPERED")
+
+    result = runner.invoke(
+        app, ["skills", "upgrade", "--platform", "claude-code-user"]
+    )
+    assert result.exit_code == 0, result.stdout
+    assert (dest / "SKILL.md").read_text().startswith("---")
+
+
+def test_upgrade_explicit_platform_must_be_installed(runner, tmp_path, monkeypatch):
+    _install(runner, tmp_path, monkeypatch)  # claude-code-user only
+    result = runner.invoke(
+        app, ["skills", "upgrade", "--platform", "codex"]
+    )
+    assert result.exit_code != 0
+    output = (result.stdout or "") + (result.stderr or "")
+    assert "not installed" in output.lower()

--- a/tests/test_skills_lifecycle.py
+++ b/tests/test_skills_lifecycle.py
@@ -50,7 +50,8 @@ def test_full_lifecycle(runner, tmp_path, monkeypatch):
     r = runner.invoke(app, ["skills", "bootstrap"])
     assert r.exit_code == 0, r.stdout
     firm = dest / "firm"
-    assert (firm / "_meta.json").exists()
+    assert (dest / "_meta.json").exists()
+    assert not (firm / "_meta.json").exists()
 
     # mutate hand-edited file
     (firm / "contacts.md").write_text("# user policy\n")


### PR DESCRIPTION
## Summary

- Add `wbox skills upgrade` — re-copies bundled template (SKILL.md, references/, firm-examples/, bootstrap.md) into every installed platform while preserving each install's `firm/` directory. Fills the gap left by `install --force`, which clobbered firm/.
- Schema change: `_meta.json` moves from `<skill>/firm/_meta.json` to the skill root with a `{template, firm}` split. `install` / `upgrade` writes the template section; `bootstrap` / `refresh` writes the firm section. Each preserves the other.
- SKILL.md gains a Staleness Check section directing agents to compare `_meta.json.template.cli_version` against `wbox --version` and suggest `wbox skills upgrade` on drift.
- First-run trigger now keys on `_meta.json.firm` absence (previously `firm/_meta.json`), and the bootstrap.md self-trim instructions are removed since the trigger re-evaluates cleanly.
- Bump to 1.1.2.

## Test plan

- [x] `ruff check src/ tests/` clean
- [x] `pytest` — 214 passed (8 new upgrade tests + updated existing tests for new schema)
- [x] `wbox --version` reports `1.1.2`
- [x] `wbox skills upgrade -h` renders new command
- [ ] Manual smoke: install, modify SKILL.md and firm/contacts.md, run `wbox skills upgrade`, verify SKILL.md restored and firm/contacts.md untouched

## Migration

No backwards-compat shim — only one user (Kadin) has existing 1.1.1 installs. Those installs will need a one-time `wbox skills install --force` (which discards `firm/`) or a manual move of `firm/_meta.json` -> `_meta.json` (reshape to new schema). New installs and upgrades from 1.1.2 onward use the new layout natively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)