### PR TITLE
v1.1.3: preserve onboarded state and reject same-path sync targets

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wealthbox-cli"
-version = "1.1.2"
+version = "1.1.3"
 description = "CLI and client library for the Wealthbox CRM API"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/wealthbox_tools/cli/_skill_bootstrap.py
+++ b/src/wealthbox_tools/cli/_skill_bootstrap.py
@@ -187,6 +187,20 @@ def update_firm_meta(
     write_meta(skill_dir, meta)
 
 
+def copy_firm_meta(src_skill_dir: Path, dst_skill_dir: Path) -> bool:
+    """Copy the firm section of _meta.json from src to dst, preserving dst's template.
+
+    Returns True if a firm section was copied, False if src had none.
+    """
+    src_firm = read_meta(src_skill_dir).get("firm")
+    if not src_firm:
+        return False
+    dst_meta = read_meta(dst_skill_dir)
+    dst_meta["firm"] = src_firm
+    write_meta(dst_skill_dir, dst_meta)
+    return True
+
+
 # --------------------------------------------------------------------------- #
 # Orchestrator                                                                 #
 # --------------------------------------------------------------------------- #

--- a/src/wealthbox_tools/cli/skills.py
+++ b/src/wealthbox_tools/cli/skills.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import typer
 
-from ._skill_bootstrap import read_meta, update_template_meta
+from ._skill_bootstrap import copy_firm_meta, read_meta, update_template_meta
 from ._skill_platforms import (
     Platform,
     SkillInstallError,
@@ -376,7 +376,12 @@ def sync_cmd(
         )
         raise typer.Exit(code=2)
 
-    others = [p for p in installed if p.id != source.id]
+    src_resolved = skill_dir(source).resolve()
+
+    def _is_same_path(p: Platform) -> bool:
+        return skill_dir(p).resolve() == src_resolved
+
+    others = [p for p in installed if p.id != source.id and not _is_same_path(p)]
 
     if all_targets and target_ids:
         typer.echo("Error: --all-targets and --target are mutually exclusive.", err=True)
@@ -387,8 +392,12 @@ def sync_cmd(
     elif target_ids:
         targets = _resolve_platforms(target_ids)
         for t in targets:
-            if t.id == source.id:
-                typer.echo(f"Error: target {t.id!r} is the same as the source.", err=True)
+            if t.id == source.id or _is_same_path(t):
+                typer.echo(
+                    f"Error: target {t.id!r} is the same as the source "
+                    f"(resolves to {src_resolved}).",
+                    err=True,
+                )
                 raise typer.Exit(code=2)
             if not is_installed(t):
                 typer.echo(f"Error: target {t.id!r} is not installed.", err=True)
@@ -425,7 +434,11 @@ def sync_cmd(
         tgt_firm = skill_dir(t) / "firm"
         tgt_firm.mkdir(parents=True, exist_ok=True)
         shutil.copytree(src_firm, tgt_firm, dirs_exist_ok=True)
-        typer.echo(f"OK synced {len(src_files)} files: {source.id} -> {t.id}")
+        meta_copied = copy_firm_meta(skill_dir(source), skill_dir(t))
+        meta_note = "" if meta_copied else " (no _meta.json firm section on source)"
+        typer.echo(
+            f"OK synced {len(src_files)} files: {source.id} -> {t.id}{meta_note}"
+        )
 
 
 @app.command("uninstall", help="Remove the wealthbox-crm skill from a platform.")

--- a/tests/test_skills_cli_sync.py
+++ b/tests/test_skills_cli_sync.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 from wealthbox_tools.cli.main import app
@@ -125,6 +126,123 @@ def test_sync_all_targets_fans_out(runner, tmp_path, monkeypatch):
     project_target = _firm_dir(home, project, "claude-code-project")
     assert (user_target / "notes.md").read_text() == "FANNED OUT"
     assert (project_target / "notes.md").read_text() == "FANNED OUT"
+
+
+def _skill_root(home: Path, project: Path, platform_id: str) -> Path:
+    return _firm_dir(home, project, platform_id).parent
+
+
+def test_sync_propagates_firm_meta_section(runner, tmp_path, monkeypatch):
+    """After sync, the target's _meta.json should carry the source's firm section
+    so the SKILL.md first-run gate doesn't trigger another bootstrap."""
+    home, project = _setup(runner, tmp_path, monkeypatch, "codex", "claude-code-project")
+
+    src_root = _skill_root(home, project, "codex")
+    src_firm = src_root / "firm"
+    src_firm.mkdir(parents=True, exist_ok=True)
+    (src_firm / "categories.md").write_text("# generated\n")
+
+    src_meta = {
+        "template": {"cli_version": "1.1.2"},
+        "firm": {
+            "identity": {"id": 42, "name": "Acme Wealth"},
+            "cli_version": "1.1.2",
+            "files": {"categories.md": "2026-05-01T00:00:00+00:00"},
+        },
+    }
+    (src_root / "_meta.json").write_text(json.dumps(src_meta))
+
+    tgt_root = _skill_root(home, project, "claude-code-project")
+    tgt_meta = {"template": {"cli_version": "1.1.2"}}
+    (tgt_root / "_meta.json").write_text(json.dumps(tgt_meta))
+
+    result = runner.invoke(
+        app,
+        ["skills", "sync", "-s", "codex", "-t", "claude-code-project", "--yes"],
+    )
+    assert result.exit_code == 0, result.stdout + (result.stderr or "")
+
+    written = json.loads((tgt_root / "_meta.json").read_text())
+    assert written["firm"] == src_meta["firm"]
+    assert written["template"] == {"cli_version": "1.1.2"}
+
+
+def test_sync_notes_when_source_has_no_firm_meta(runner, tmp_path, monkeypatch):
+    """If the source has no firm section yet, sync should still succeed but flag it."""
+    home, project = _setup(runner, tmp_path, monkeypatch, "codex", "claude-code-project")
+    src_firm = _firm_dir(home, project, "codex")
+    src_firm.mkdir(parents=True, exist_ok=True)
+    (src_firm / "categories.md").write_text("# generated\n")
+
+    result = runner.invoke(
+        app,
+        ["skills", "sync", "-s", "codex", "-t", "claude-code-project", "--yes"],
+    )
+    assert result.exit_code == 0, result.stdout + (result.stderr or "")
+    assert "no _meta.json firm section" in result.stdout.lower()
+
+
+def test_sync_rejects_target_resolving_to_same_path(runner, tmp_path, monkeypatch):
+    """When cwd == HOME, claude-code-user and claude-code-project resolve to the
+    same skill dir; sync must refuse instead of running shutil.copytree on itself."""
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / ".git").mkdir()  # satisfy _project_scope_allowed when cwd == home
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+    monkeypatch.chdir(home)
+
+    install_user = runner.invoke(
+        app, ["skills", "install", "--platform", "claude-code-user", "--no-bootstrap"]
+    )
+    assert install_user.exit_code == 0, install_user.stdout
+
+    user_skill = home / ".claude" / "skills" / "wealthbox-crm"
+    project_skill = home / ".claude" / "skills" / "wealthbox-crm"
+    assert user_skill.resolve() == project_skill.resolve()
+
+    src_firm = user_skill / "firm"
+    src_firm.mkdir(parents=True, exist_ok=True)
+    (src_firm / "categories.md").write_text("# generated\n")
+
+    result = runner.invoke(
+        app,
+        [
+            "skills", "sync",
+            "-s", "claude-code-user",
+            "-t", "claude-code-project",
+            "--yes",
+        ],
+    )
+    assert result.exit_code != 0
+    output = (result.stdout or "") + (result.stderr or "")
+    assert "same as the source" in output.lower()
+
+
+def test_sync_all_targets_skips_same_path_collision(runner, tmp_path, monkeypatch):
+    """--all-targets must filter out platforms whose skill dir resolves to the source's."""
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / ".git").mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+    monkeypatch.chdir(home)
+
+    runner.invoke(app, ["skills", "install", "--platform", "claude-code-user", "--no-bootstrap"])
+    runner.invoke(app, ["skills", "install", "--platform", "codex", "--no-bootstrap"])
+
+    src_firm = home / ".claude" / "skills" / "wealthbox-crm" / "firm"
+    src_firm.mkdir(parents=True, exist_ok=True)
+    (src_firm / "categories.md").write_text("# generated\n")
+
+    result = runner.invoke(
+        app,
+        ["skills", "sync", "-s", "claude-code-user", "--all-targets", "--yes"],
+    )
+    assert result.exit_code == 0, result.stdout + (result.stderr or "")
+    # codex should be the only synced target; claude-code-project must be filtered out.
+    assert "-> codex" in result.stdout
+    assert "-> claude-code-project" not in result.stdout
 
 
 def test_sync_rejects_all_targets_with_explicit_target(runner, tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

Addresses two P2 issues flagged by Codex on PRs #6 and #7.

- **Preserve onboarded state on sync (#7 review):** `wbox skills sync` now copies the source's `_meta.json` `firm` section into each target, preserving the target's existing `template` section. Previously sync only copied `firm/` files; the new first-run gate in `SKILL.md` (which checks for `_meta.json.firm`) would still treat the target as un-onboarded and trigger another bootstrap on the very next run.
- **Reject same-path sync targets (#6 review):** `claude-code-user` (`~/.claude/skills`) and `claude-code-project` (`cwd/.claude/skills`) resolve to the same directory when `cwd == HOME`. The previous guard only compared platform IDs, so `shutil.copytree` would attempt to copy a tree onto itself and abort. Sync now compares resolved paths and rejects same-path targets in the explicit `--target` branch and filters them out for `--all-targets` / interactive prompts.

Bumps version to `1.1.3`.

## Test plan
- [x] `ruff check src/ tests/` clean
- [x] Full `pytest` suite (218 tests) passes
- [x] New tests cover: firm-meta propagation, "no source firm meta" notice, same-path rejection (explicit), same-path filtering (`--all-targets`)
- [x] CI green on Python 3.11/3.12/3.13

🤖 Generated with [Claude Code](https://claude.com/claude-code)