### PR TITLE
feat(cli): workspace-level category aliases (v1.1.4)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,16 @@ This project uses [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [1.1.4](https://github.com/massive-value/wealthbox-cli/releases/tag/v1.1.4) — 2026-05-01
+
+### Added
+- Workspace-level aliases for every resource-scoped category lookup. `wbox categories contact-types`, `wbox categories contact-roles`, `wbox categories event-categories`, `wbox categories task-categories`, and the rest now work alongside their existing `wbox <resource> categories` forms. Both routes call the same API endpoint.
+
+### Docs
+- Skill references (`lookups.md`, `contacts.md`) and `docs/cli-reference.md` updated to surface the workspace-level form as the primary listing.
+
+---
+
 ## [1.0.2](https://github.com/massive-value/wealthbox-cli/releases/tag/v1.0.2) — 2026-03-30
 
 ### Changed

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -343,7 +343,18 @@ wbox categories opportunity-stages
 wbox categories opportunity-pipelines
 wbox categories investment-objectives
 wbox categories financial-account-types
+wbox categories contact-types
+wbox categories contact-sources
+wbox categories email-types
+wbox categories phone-types
+wbox categories address-types
+wbox categories website-types
+wbox categories contact-roles
+wbox categories event-categories
+wbox categories task-categories
 ```
+
+The contact category types (contact-types, contact-sources, email-types, phone-types, address-types, website-types, contact-roles) are also reachable under `wbox contacts categories <name>`. `wbox events categories` and `wbox tasks categories` are aliases for `wbox categories event-categories` and `wbox categories task-categories`. Both forms call the same API endpoint.
 
 ### Custom Fields
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wealthbox-cli"
-version = "1.1.3"
+version = "1.1.4"
 description = "CLI and client library for the Wealthbox CRM API"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/wealthbox_tools/cli/categories.py
+++ b/src/wealthbox_tools/cli/categories.py
@@ -26,6 +26,27 @@ app.command("investment-objectives", help="List investment objective options.")(
 app.command("financial-account-types", help="List financial account type options.")(
     make_category_command(CategoryType.FINANCIAL_ACCOUNT_TYPES)
 )
+app.command("contact-types", help="List contact type options.")(make_category_command(CategoryType.CONTACT_TYPES))
+app.command("contact-sources", help="List contact source options.")(
+    make_category_command(CategoryType.CONTACT_SOURCES)
+)
+app.command("email-types", help="List email type options.")(make_category_command(CategoryType.EMAIL_TYPES))
+app.command("phone-types", help="List phone type options.")(make_category_command(CategoryType.PHONE_TYPES))
+app.command("address-types", help="List address type options.")(
+    make_category_command(CategoryType.ADDRESS_TYPES)
+)
+app.command("website-types", help="List website type options.")(
+    make_category_command(CategoryType.WEBSITE_TYPES)
+)
+app.command("contact-roles", help="List contact role options.")(
+    make_category_command(CategoryType.CONTACT_ROLES)
+)
+app.command("event-categories", help="List event category options.")(
+    make_category_command(CategoryType.EVENT_CATEGORIES)
+)
+app.command("task-categories", help="List task category options.")(
+    make_category_command(CategoryType.TASK_CATEGORIES)
+)
 
 
 @app.command("custom-fields", help="List custom field categories. Optionally filter by document type.")

--- a/src/wealthbox_tools/skills/wealthbox-crm/references/contacts.md
+++ b/src/wealthbox_tools/skills/wealthbox-crm/references/contacts.md
@@ -122,6 +122,8 @@ No output on success.
 
 ## Contact Categories
 
+Each of these is also available at the workspace level via `wbox categories <name>` — both forms return the same data.
+
 ```bash
 wbox contacts categories contact-types
 wbox contacts categories contact-sources

--- a/src/wealthbox_tools/skills/wealthbox-crm/references/lookups.md
+++ b/src/wealthbox_tools/skills/wealthbox-crm/references/lookups.md
@@ -36,7 +36,9 @@ wbox activity list [OPTIONS]
 
 **Important:** Activity uses cursor-based pagination, NOT `--page`/`--per-page`. Use the cursor value from the previous response for the next page.
 
-## Workspace-Level Categories
+## Categories
+
+Every category type is available under `wbox categories <name>`. The full set:
 
 ```bash
 wbox categories tags
@@ -45,16 +47,19 @@ wbox categories opportunity-stages
 wbox categories opportunity-pipelines
 wbox categories investment-objectives
 wbox categories financial-account-types
+wbox categories contact-types
+wbox categories contact-sources
+wbox categories email-types
+wbox categories phone-types
+wbox categories address-types
+wbox categories website-types
+wbox categories contact-roles
+wbox categories event-categories
+wbox categories task-categories
 wbox categories custom-fields [--document-type STR] [--page INT] [--per-page INT] [--format ...]
 ```
 
-## Resource-Scoped Categories
-
-```bash
-wbox contacts categories {contact-types|contact-sources|email-types|phone-types|address-types|website-types|contact-roles}
-wbox events categories
-wbox tasks categories
-```
+The contact-related types are also reachable as aliases under `wbox contacts categories <name>` (contact-types, contact-sources, email-types, phone-types, address-types, website-types, contact-roles). Likewise, `wbox events categories` and `wbox tasks categories` are aliases for `wbox categories event-categories` and `wbox categories task-categories`. Either form returns the same data.
 
 ## Examples
 
@@ -69,5 +74,5 @@ wbox users list --format table
 wbox activity list --contact 12345 --format table
 
 # Look up valid contact types
-wbox contacts categories contact-types
+wbox categories contact-types
 ```


### PR DESCRIPTION
## Summary
- Adds workspace-level aliases under `wbox categories` for every resource-scoped category type — `contact-types`, `contact-sources`, `email-types`, `phone-types`, `address-types`, `website-types`, `contact-roles`, `event-categories`, `task-categories`. The full set of 16 category types is now reachable from a single root, while existing resource-scoped routes (`wbox contacts categories ...`, `wbox events categories`, `wbox tasks categories`) remain unchanged.
- Pure additive change — no client, model, or bootstrap modifications. Each new alias is a one-liner using the existing `make_category_command()` factory, so the workspace and resource-scoped forms call the same API endpoint and return identical output (verified by diffing live responses).
- Skill references (`lookups.md`, `contacts.md`) and `docs/cli-reference.md` updated to surface the workspace-level form as the primary listing; resource-scoped routes documented as equivalent aliases. Version bumped to 1.1.4 with changelog entry.

## Test plan
- [x] `ruff check src/ tests/` clean
- [x] `pytest` — 218 passed
- [x] `wbox categories --help` lists all 16 subcommands
- [x] `wbox categories contact-roles --format json` matches `wbox contacts categories contact-roles --format json` byte-for-byte
- [x] `wbox categories event-categories` and `wbox categories task-categories` return live data
- [x] `wbox --version` reports `1.1.4`
- [x] CI lint + test jobs pass on the PR
- [ ] On merge to `main` + `v1.1.4` tag, PyPI publish job succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)