### PR TITLE
fix(skills): honor config-file token during bootstrap (v1.1.5)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,17 @@ This project uses [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [1.1.5](https://github.com/massive-value/wealthbox-cli/releases/tag/v1.1.5) — 2026-05-01
+
+### Fixed
+- `wbox skills install`, `wbox skills bootstrap`, and `wbox skills refresh` now honor every token source the rest of the CLI does. Previously these commands only looked at the `--token` flag and `WEALTHBOX_TOKEN` env var, ignoring tokens stored via `wbox config set-token` and `.env` files. Users running `wbox skills install` after `wbox config set-token` saw "Wealthbox token required" errors despite having a token set.
+- The "token required" error message now lists every supported source (flag, env var, config file, `.env`).
+
+### Added
+- `wbox skills install` accepts `--token` (matching `bootstrap`, `refresh`, and `doctor`), so a token can be supplied inline for the post-install bootstrap step.
+
+---
+
 ## [1.1.4](https://github.com/massive-value/wealthbox-cli/releases/tag/v1.1.4) — 2026-05-01
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wealthbox-cli"
-version = "1.1.4"
+version = "1.1.5"
 description = "CLI and client library for the Wealthbox CRM API"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/wealthbox_tools/cli/_skill_bootstrap.py
+++ b/src/wealthbox_tools/cli/_skill_bootstrap.py
@@ -212,6 +212,8 @@ from importlib.metadata import version as _pkg_version  # noqa: E402
 from wealthbox_tools.client import WealthboxClient  # noqa: E402
 from wealthbox_tools.models import CategoryListQuery, CategoryType, DocumentType  # noqa: E402
 
+from ._util import get_client  # noqa: E402
+
 
 @dataclass
 class BootstrapResult:
@@ -264,7 +266,7 @@ def bootstrap_skill_dir(
     firm_dir.mkdir(parents=True, exist_ok=True)
 
     async def _run() -> tuple[dict, dict, list, dict]:
-        async with WealthboxClient(token=token) as client:
+        async with get_client(token) as client:
             return await _fetch_all(client)
 
     categories, custom_fields, users, firm_identity = asyncio.run(_run())

--- a/src/wealthbox_tools/cli/_util.py
+++ b/src/wealthbox_tools/cli/_util.py
@@ -62,6 +62,12 @@ def get_client(token: str | None = None) -> WealthboxClient:
             token = os.environ.get("WEALTHBOX_TOKEN")
         except ImportError:
             pass
+    if not token:
+        raise ValueError(
+            "Wealthbox token required. Provide one via any of: "
+            "--token flag, WEALTHBOX_TOKEN env var, "
+            "`wbox config set-token`, or a .env file in the working directory."
+        )
     return WealthboxClient(token=token)
 
 

--- a/src/wealthbox_tools/cli/skills.py
+++ b/src/wealthbox_tools/cli/skills.py
@@ -98,6 +98,7 @@ def install_cmd(
     ),
     force: bool = typer.Option(False, "--force", help="Overwrite existing install."),
     no_bootstrap: bool = typer.Option(False, "--no-bootstrap", help="Skip the post-install bootstrap prompt."),
+    token: str | None = typer.Option(None, envvar="WEALTHBOX_TOKEN", hidden=True),
 ) -> None:
     targets = _resolve_platforms(platforms_flag) if platforms_flag else _prompt_platforms()
 
@@ -122,7 +123,7 @@ def install_cmd(
         if typer.confirm("Run 'wbox skills bootstrap' now?", default=True):
             from ._skill_bootstrap import bootstrap_skill_dir
             for target in targets:
-                bootstrap_skill_dir(skill_dir(target), token=None, generated_only=False)
+                bootstrap_skill_dir(skill_dir(target), token=token, generated_only=False)
                 typer.echo(f"OK bootstrapped {target.id}")
 
 

--- a/tests/test_skills_cli_token_resolution.py
+++ b/tests/test_skills_cli_token_resolution.py
@@ -1,0 +1,97 @@
+"""Regression tests: skills bootstrap must honor every token source the rest of
+the CLI honors (--token > WEALTHBOX_TOKEN > config file > .env).
+
+Before v1.1.5, ``bootstrap_skill_dir`` constructed ``WealthboxClient`` directly
+and only fell back to the env var, ignoring tokens stored via
+``wbox config set-token``.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+
+from wealthbox_tools.cli._config import save_config
+from wealthbox_tools.cli.main import app
+from wealthbox_tools.models.enums import CategoryType, DocumentType
+
+_BASE = "https://api.crmworkspace.com/v1"
+
+
+@pytest.fixture
+def config_token_only(monkeypatch, tmp_path):
+    """Isolate every token source EXCEPT the config file, then write a config-file token."""
+    monkeypatch.delenv("WEALTHBOX_TOKEN", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    monkeypatch.setenv("APPDATA", str(tmp_path / "AppData"))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / ".config"))
+    monkeypatch.chdir(tmp_path)
+    save_config({"token": "config-file-token"})
+
+
+def _setup_api_mocks():
+    for ct in CategoryType:
+        if ct is CategoryType.CUSTOM_FIELDS:
+            continue
+        respx.get(f"{_BASE}/categories/{ct.value}").mock(
+            return_value=httpx.Response(200, json={ct.value: []})
+        )
+    for dt in DocumentType:
+        respx.get(
+            f"{_BASE}/categories/custom_fields",
+            params={"document_type": dt.value},
+        ).mock(return_value=httpx.Response(200, json={"custom_fields": []}))
+    respx.get(f"{_BASE}/users").mock(
+        return_value=httpx.Response(200, json={"users": []})
+    )
+    respx.get(f"{_BASE}/me").mock(
+        return_value=httpx.Response(
+            200, json={"id": 1, "name": "Adv", "accounts": [{"id": 100, "name": "Firm"}]}
+        )
+    )
+
+
+@respx.mock
+def test_bootstrap_uses_config_file_token_when_env_unset(runner, config_token_only):
+    """`wbox skills bootstrap` must succeed when only a config-file token is set."""
+    _setup_api_mocks()
+
+    install = runner.invoke(
+        app, ["skills", "install", "--platform", "claude-code-user", "--no-bootstrap"]
+    )
+    assert install.exit_code == 0, install.stdout
+
+    result = runner.invoke(app, ["skills", "bootstrap"])
+    assert result.exit_code == 0, (result.stdout, result.stderr)
+    assert "OK bootstrapped" in result.stdout
+
+
+@respx.mock
+def test_bootstrap_sends_config_file_token_in_header(runner, config_token_only):
+    """The token reaches the API as the ACCESS_TOKEN header."""
+    _setup_api_mocks()
+
+    runner.invoke(
+        app, ["skills", "install", "--platform", "claude-code-user", "--no-bootstrap"]
+    )
+    runner.invoke(app, ["skills", "bootstrap"])
+
+    me_calls = [c for c in respx.calls if c.request.url.path.endswith("/me")]
+    assert me_calls, "bootstrap never called /me"
+    assert me_calls[0].request.headers.get("ACCESS_TOKEN") == "config-file-token"
+
+
+@respx.mock
+def test_refresh_uses_config_file_token_when_env_unset(runner, config_token_only):
+    """`wbox skills refresh` shares the bootstrap token-resolution path."""
+    _setup_api_mocks()
+
+    runner.invoke(
+        app, ["skills", "install", "--platform", "claude-code-user", "--no-bootstrap"]
+    )
+    runner.invoke(app, ["skills", "bootstrap"])
+
+    result = runner.invoke(app, ["skills", "refresh"])
+    assert result.exit_code == 0, (result.stdout, result.stderr)


### PR DESCRIPTION
## Summary
- **Bug:** `wbox skills install`, `wbox skills bootstrap`, and `wbox skills refresh` only honored `--token` and `WEALTHBOX_TOKEN` — they ignored tokens set via `wbox config set-token` and `.env` files. Users who configured their token through the CLI saw "Wealthbox token required. Pass token= or set WEALTHBOX_TOKEN env var." despite having a working token on disk.
- **Root cause:** `bootstrap_skill_dir` (in `cli/_skill_bootstrap.py`) constructed `WealthboxClient(token=token)` directly, bypassing the 4-layer token resolution chain that every other CLI command goes through (`get_client()` in `cli/_util.py`).
- **Fix:** Route the bootstrap path through `get_client()` so the same `--token > env > config file > .env` order applies. Also improves the unresolved-token error message to list every supported source, and adds `--token` to `install_cmd` (matching `bootstrap`/`refresh`/`doctor`).

## Test plan
- [x] Three new regression tests in `tests/test_skills_cli_token_resolution.py` covering bootstrap, refresh, and the ACCESS_TOKEN header path with only a config-file token configured. Verified they fail on the previous code and pass after the fix.
- [x] `ruff check src/ tests/` — clean
- [x] `pytest` — 221 passed (218 existing + 3 new)
- [x] `wbox --version` reports `1.1.5`
- [ ] CI lint + test jobs pass on the PR
- [ ] On merge to `main` + `v1.1.5` tag, PyPI publish job succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)