### PR TITLE
fix(install): bash exec-tty hang + ps1 silent error close

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -5,61 +5,102 @@
 #
 # Installs uv (if missing), installs wealthbox-cli as an isolated tool,
 # prompts for the API token, and offers to install the AI agent skill.
+#
+# Wrapped in a try/finally so the window stays open long enough to read
+# the result even if the parent shell would otherwise auto-close on exit.
+
 $ErrorActionPreference = "Stop"
 
-Write-Host "=== wealthbox-cli installer ===" -ForegroundColor Cyan
-Write-Host ""
-
-if (-not (Get-Command uv -ErrorAction SilentlyContinue)) {
-    Write-Host "Installing uv (Python tool manager)..."
-    Invoke-RestMethod https://astral.sh/uv/install.ps1 | Invoke-Expression
-    $env:Path = "$env:USERPROFILE\.local\bin;$env:Path"
-}
-
-$installed = $false
-try {
-    $toolList = (uv tool list 2>$null) -join "`n"
-    if ($toolList -match '(?m)^wealthbox-cli\s') {
-        $installed = $true
-    }
-} catch {
-    $installed = $false
-}
-
-if ($installed) {
-    Write-Host "Upgrading wealthbox-cli to latest..."
-    uv tool upgrade wealthbox-cli
-} else {
-    Write-Host "Installing wealthbox-cli..."
-    uv tool install wealthbox-cli
-}
-
-# uv installs tool entry points to %USERPROFILE%\.local\bin; ensure it's
-# on PATH for the rest of this session.
-$env:Path = "$env:USERPROFILE\.local\bin;$env:Path"
-
-if (-not (Get-Command wbox -ErrorAction SilentlyContinue)) {
+function Write-Step {
+    param([string]$Message)
     Write-Host ""
-    Write-Host "wbox installed but not on PATH in this shell." -ForegroundColor Yellow
-    Write-Host "Open a new terminal and run:"
-    Write-Host "    wbox config set-token"
-    Write-Host "    wbox skills install"
-    return
+    Write-Host "[*] $Message" -ForegroundColor Cyan
 }
 
-Write-Host ""
-Write-Host "Get your Wealthbox API token at https://dev.wealthbox.com"
-Write-Host "(Settings -> API Access -> Access Tokens)"
-Write-Host ""
-wbox config set-token
+$installerSucceeded = $false
 
-Write-Host ""
-$installSkill = Read-Host "Install the AI agent skill (Claude Code / Codex)? [Y/n]"
-if ($installSkill -match '^[Nn]') {
-    Write-Host "Skipped. Run 'wbox skills install' anytime."
-} else {
-    wbox skills install
+try {
+    Write-Host "=== wealthbox-cli installer ===" -ForegroundColor Cyan
+
+    Write-Step "Checking for uv (Python tool manager)..."
+    if (-not (Get-Command uv -ErrorAction SilentlyContinue)) {
+        Write-Host "  uv not found. Installing from astral.sh..."
+        Invoke-RestMethod https://astral.sh/uv/install.ps1 | Invoke-Expression
+        $env:Path = "$env:USERPROFILE\.local\bin;$env:Path"
+    } else {
+        Write-Host "  uv found at $((Get-Command uv).Source)"
+    }
+
+    Write-Step "Installing or upgrading wealthbox-cli..."
+    $installed = $false
+    try {
+        $toolList = (uv tool list 2>$null) -join "`n"
+        if ($toolList -match '(?m)^wealthbox-cli\s') {
+            $installed = $true
+        }
+    } catch {
+        $installed = $false
+    }
+    if ($installed) {
+        Write-Host "  Upgrading existing wealthbox-cli install..."
+        uv tool upgrade wealthbox-cli
+    } else {
+        Write-Host "  Installing wealthbox-cli..."
+        uv tool install wealthbox-cli
+    }
+
+    # uv installs tool entry points to %USERPROFILE%\.local\bin; ensure
+    # it's on PATH for the rest of this session.
+    $env:Path = "$env:USERPROFILE\.local\bin;$env:Path"
+
+    Write-Step "Verifying wbox is on PATH..."
+    if (-not (Get-Command wbox -ErrorAction SilentlyContinue)) {
+        Write-Host "  wbox installed but not on PATH in this shell." -ForegroundColor Yellow
+        Write-Host "  Open a new terminal and run:"
+        Write-Host "    wbox config set-token"
+        Write-Host "    wbox skills install"
+        $installerSucceeded = $true
+        return
+    }
+    Write-Host "  wbox found at $((Get-Command wbox).Source)"
+
+    Write-Step "Configuring API token..."
+    Write-Host "  Get your Wealthbox API token at https://dev.wealthbox.com"
+    Write-Host "  (Settings -> API Access -> Access Tokens)"
+    Write-Host ""
+    wbox config set-token
+
+    Write-Step "Skill install..."
+    $installSkill = Read-Host "Install the AI agent skill (Claude Code / Codex)? [Y/n]"
+    if ($installSkill -match '^[Nn]') {
+        Write-Host "  Skipped. Run 'wbox skills install' anytime."
+    } else {
+        wbox skills install
+    }
+
+    Write-Host ""
+    Write-Host "Done. Try: wbox me" -ForegroundColor Green
+    $installerSucceeded = $true
 }
-
-Write-Host ""
-Write-Host "Done. Try: wbox me" -ForegroundColor Green
+catch {
+    Write-Host ""
+    Write-Host "ERROR: $($_.Exception.Message)" -ForegroundColor Red
+    if ($_.InvocationInfo) {
+        Write-Host "  at $($_.InvocationInfo.PositionMessage)" -ForegroundColor DarkGray
+    }
+    Write-Host ""
+    Write-Host "Please report this at:" -ForegroundColor Yellow
+    Write-Host "  https://github.com/massive-value/wealthbox-cli/issues"
+}
+finally {
+    # Keep the window open if this is a transient PowerShell host (e.g.
+    # double-click, `Run with PowerShell`, or `powershell -Command`),
+    # which would otherwise close as soon as the script returns.
+    Write-Host ""
+    if ($installerSucceeded) {
+        Write-Host "Press Enter to close this window..." -ForegroundColor DarkGray
+    } else {
+        Write-Host "Press Enter to close this window (an error occurred)..." -ForegroundColor Yellow
+    }
+    try { $null = Read-Host } catch { Start-Sleep -Seconds 30 }
+}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -6,57 +6,96 @@
 #
 # Installs uv (if missing), installs wealthbox-cli as an isolated tool,
 # prompts for the API token, and offers to install the AI agent skill.
+#
+# Note: the entire body lives inside main() so that bash reads the whole
+# script into memory before executing. Without this, `curl | bash` reads
+# the script as a stream from stdin — and any later stdin redirection
+# (e.g. for /dev/tty prompts) would cut off bash's source mid-script and
+# hang the install before it printed a single line.
 set -euo pipefail
 
-# When piped from curl, stdin is the pipe — redirect from the user's
-# terminal so interactive prompts (token entry, skill picker) work.
-if [ ! -t 0 ] && [ -e /dev/tty ]; then
-    exec </dev/tty
-fi
-
-echo "=== wealthbox-cli installer ==="
-echo
-
-if ! command -v uv >/dev/null 2>&1; then
-    echo "Installing uv (Python tool manager)..."
-    curl -LsSf https://astral.sh/uv/install.sh | sh
-    export PATH="$HOME/.local/bin:$PATH"
-fi
-
-if uv tool list 2>/dev/null | grep -qE '^wealthbox-cli[[:space:]]'; then
-    echo "Upgrading wealthbox-cli to latest..."
-    uv tool upgrade wealthbox-cli
-else
-    echo "Installing wealthbox-cli..."
-    uv tool install wealthbox-cli
-fi
-
-# uv installs tool entry points to ~/.local/bin; ensure it's on PATH for
-# the rest of this session.
-export PATH="$HOME/.local/bin:$PATH"
-
-if ! command -v wbox >/dev/null 2>&1; then
+main() {
+    echo "=== wealthbox-cli installer ==="
     echo
-    echo "wbox installed but not on PATH in this shell."
-    echo "Open a new terminal and run:"
-    echo "    wbox config set-token"
-    echo "    wbox skills install"
-    exit 0
-fi
 
-echo
-echo "Get your Wealthbox API token at https://dev.wealthbox.com"
-echo "(Settings -> API Access -> Access Tokens)"
-echo
-wbox config set-token
+    if ! command -v uv >/dev/null 2>&1; then
+        echo "Installing uv (Python tool manager)..."
+        curl -LsSf https://astral.sh/uv/install.sh | sh
+        export PATH="$HOME/.local/bin:$PATH"
+    fi
 
-echo
-printf "Install the AI agent skill (Claude Code / Codex)? [Y/n] "
-read -r install_skill || install_skill=""
-case "$install_skill" in
-    [Nn]*) echo "Skipped. Run 'wbox skills install' anytime." ;;
-    *)     wbox skills install ;;
-esac
+    if uv tool list 2>/dev/null | grep -qE '^wealthbox-cli[[:space:]]'; then
+        echo "Upgrading wealthbox-cli to latest..."
+        uv tool upgrade wealthbox-cli
+    else
+        echo "Installing wealthbox-cli..."
+        uv tool install wealthbox-cli
+    fi
 
-echo
-echo "Done. Try: wbox me"
+    # uv installs tool entry points to ~/.local/bin; ensure it's on PATH
+    # for the rest of this session.
+    export PATH="$HOME/.local/bin:$PATH"
+
+    if ! command -v wbox >/dev/null 2>&1; then
+        echo
+        echo "wbox installed but not on PATH in this shell."
+        echo "Open a new terminal and run:"
+        echo "    wbox config set-token"
+        echo "    wbox skills install"
+        return 0
+    fi
+
+    # Detect whether we have a real terminal for the interactive prompts.
+    # When piped from curl, stdin is the pipe (not a tty) but /dev/tty is
+    # usually still attached to the user's terminal. If neither is true,
+    # skip the prompts and tell the user how to finish manually.
+    local tty=""
+    if [ -t 0 ]; then
+        tty="stdin"
+    elif [ -r /dev/tty ] && [ -w /dev/tty ] && (: < /dev/tty) >/dev/null 2>&1; then
+        tty="/dev/tty"
+    fi
+
+    if [ -z "$tty" ]; then
+        echo
+        echo "wbox is installed. To finish setup, run from an interactive shell:"
+        echo "    wbox config set-token"
+        echo "    wbox skills install"
+        return 0
+    fi
+
+    echo
+    echo "Get your Wealthbox API token at https://dev.wealthbox.com"
+    echo "(Settings -> API Access -> Access Tokens)"
+    echo
+    if [ "$tty" = "/dev/tty" ]; then
+        wbox config set-token </dev/tty
+    else
+        wbox config set-token
+    fi
+
+    echo
+    if [ "$tty" = "/dev/tty" ]; then
+        printf "Install the AI agent skill (Claude Code / Codex)? [Y/n] "
+        read -r install_skill </dev/tty || install_skill=""
+    else
+        printf "Install the AI agent skill (Claude Code / Codex)? [Y/n] "
+        read -r install_skill || install_skill=""
+    fi
+
+    case "$install_skill" in
+        [Nn]*) echo "Skipped. Run 'wbox skills install' anytime." ;;
+        *)
+            if [ "$tty" = "/dev/tty" ]; then
+                wbox skills install </dev/tty
+            else
+                wbox skills install
+            fi
+            ;;
+    esac
+
+    echo
+    echo "Done. Try: wbox me"
+}
+
+main "$@"


### PR DESCRIPTION
Fixes two install bootstrap failures hit while validating #11.

## Linux: `curl | bash` hung before printing anything

**Cause**: `exec </dev/tty` at the top of `install.sh` cut off bash's source of piped script content. Bash was waiting for the rest of the script to arrive on /dev/tty (i.e., the user's keyboard), so even the header echo never ran. Looks like a hang.

**Fix**: wrap the whole body in `main() { ... }` and call `main "$@"` at the end. Bash reads the function body to memory before executing, so subsequent stdin redirection doesn't disrupt script reading. Standard "curl | bash safe" pattern.

Also replaced the blanket `exec </dev/tty` with surgical redirects only on the commands that need a real terminal (`wbox config set-token`, the `[Y/n]` read, `wbox skills install`). Added a tty-detection step that falls through to manual-instruction text if no usable terminal is available — instead of hanging.

## Windows: window flashed header then auto-closed

**Cause**: `$ErrorActionPreference = "Stop"` terminated the script on a downstream failure (most likely Astral's uv `irm | iex`), with the parent PowerShell host auto-closing because the script ran in a transient context. No error was visible.

**Fix**: wrap everything in try/catch/finally:
- On error, print the message in red with the position info.
- Always pause on `Read-Host "Press Enter to close..."` at the very end (success OR failure) so the window stays open long enough to read.
- Replaced single-line "Installing X..." prints with `[*] Step: ...` headers so the user can pinpoint which step failed.

## Verification

- `bash -n install.sh` — clean
- PowerShell parser on `install.ps1` — clean
- **End-to-end Linux test**: piped the patched `install.sh` into a clean WSL Ubuntu. Old script: hung silently (exit 124 timeout). New script: ran uv install + `uv tool install wealthbox-cli==1.2.0` end-to-end, reached the token prompt and waited correctly for keyboard input.
- Windows verification still pending — needs a fresh terminal test (the failure mode requires a transient host context the local pwsh tool can't reproduce). Suggest landing this and re-running the cold-machine test from #11.

## Why ship now

These scripts are served live from `raw.githubusercontent.com/main/scripts/`. Any user trying the one-liner from the v1.2.0 README right now hits the hang or the silent close. Should land before announcing.
