### PR TITLE
feat(skills): plugin-aware doctor + top-level wbox doctor command

### DIFF
--- a/src/wealthbox_tools/cli/_skill_platforms.py
+++ b/src/wealthbox_tools/cli/_skill_platforms.py
@@ -4,6 +4,8 @@ import shutil
 from dataclasses import dataclass
 from pathlib import Path
 
+SKILL_NAME = "wealthbox-crm"
+
 
 @dataclass(frozen=True)
 class Platform:
@@ -14,8 +16,79 @@ class Platform:
     requires_project_cwd: bool
 
 
+@dataclass(frozen=True)
+class PluginInstall:
+    """A copy of `wealthbox-crm` discovered inside an agent host's plugin cache.
+
+    These are managed by the host CLI (`claude plugin install ...` or the
+    Codex equivalent) — `wbox skills install` does not write here, and
+    `wbox skills uninstall` does not touch them.
+    """
+    host: str        # 'claude-code-user' | 'claude-code-project' | 'codex'
+    marketplace: str
+    version: str
+    skill_dir: Path
+
+
 def _home() -> Path:
     return Path.home()
+
+
+def _scan_plugin_cache(cache_root: Path, host: str) -> list[PluginInstall]:
+    """Find any `<marketplace>/<plugin-name>/<version>/skills/wealthbox-crm/`
+    matches under a Claude Code- or Codex-style plugin cache root."""
+    if not cache_root.is_dir():
+        return []
+    out: list[PluginInstall] = []
+    for marketplace_dir in cache_root.iterdir():
+        if not marketplace_dir.is_dir():
+            continue
+        plugin_dir = marketplace_dir / SKILL_NAME
+        if not plugin_dir.is_dir():
+            continue
+        for version_dir in plugin_dir.iterdir():
+            if not version_dir.is_dir():
+                continue
+            skill_dir = version_dir / "skills" / SKILL_NAME
+            if (skill_dir / "SKILL.md").is_file():
+                out.append(PluginInstall(
+                    host=host,
+                    marketplace=marketplace_dir.name,
+                    version=version_dir.name,
+                    skill_dir=skill_dir,
+                ))
+    return out
+
+
+def detect_plugin_installs() -> list[PluginInstall]:
+    """Discover every host-managed plugin copy of wealthbox-crm on this
+    machine. Includes Claude Code user scope, Claude Code project scope
+    (cwd-relative), and Codex.
+
+    Deduped by resolved skill_dir path so a single install isn't reported
+    twice when home and cwd point at the same directory (rare in real use,
+    common in tests).
+    """
+    home = _home()
+    cwd = Path.cwd()
+    candidates = [
+        (home / ".claude" / "plugins" / "cache", "claude-code-user"),
+        (cwd / ".claude" / "plugins" / "cache", "claude-code-project"),
+        (home / ".codex" / "plugins" / "cache", "codex"),
+    ]
+    installs: list[PluginInstall] = []
+    seen: set[Path] = set()
+    for cache_root, host in candidates:
+        for pi in _scan_plugin_cache(cache_root, host=host):
+            try:
+                key = pi.skill_dir.resolve()
+            except OSError:
+                key = pi.skill_dir
+            if key in seen:
+                continue
+            seen.add(key)
+            installs.append(pi)
+    return installs
 
 
 def detect_platforms() -> list[Platform]:

--- a/src/wealthbox_tools/cli/doctor.py
+++ b/src/wealthbox_tools/cli/doctor.py
@@ -1,0 +1,199 @@
+"""Comprehensive health check across the wbox install.
+
+`wbox doctor` and `wbox skills doctor` both call into `run_doctor()` so
+the legacy `skills doctor` command keeps working as an alias.
+"""
+from __future__ import annotations
+
+import os
+import platform as _platform_module
+import shutil
+import sys
+from datetime import datetime
+from importlib.metadata import version as _pkg_version
+
+import typer
+
+from ._config import _config_path, load_config
+from ._skill_bootstrap import migrate_legacy_firm, read_firm_meta, read_meta
+from ._skill_paths import firm_dir, firm_meta_path
+from ._skill_platforms import (
+    detect_platforms,
+    detect_plugin_installs,
+    is_installed,
+    skill_dir,
+)
+
+
+def _detect_token_source(token_arg: str | None) -> tuple[str | None, str]:
+    """Return (token, source_label) matching get_client's resolution order:
+    --token flag > WEALTHBOX_TOKEN env > config file > .env (loaded as env)."""
+    if token_arg:
+        return token_arg, "--token flag"
+    env_token = os.environ.get("WEALTHBOX_TOKEN")
+    if env_token:
+        return env_token, "env var (WEALTHBOX_TOKEN or .env)"
+    cfg = load_config()
+    cfg_token = cfg.get("token")
+    if cfg_token:
+        return cfg_token, f"config file ({_config_path()})"
+    return None, "not set"
+
+
+def run_doctor(token: str | None = None) -> int:
+    """Run all health checks. Returns exit code (0 = healthy, 1 = issues found)."""
+    issues: list[str] = []
+
+    migrated_from = _ensure_firm_migrated()
+    if migrated_from is not None:
+        typer.echo(f"! migrated legacy firm/ data from {migrated_from} to {firm_dir()}")
+        typer.echo("")
+
+    # --- wbox CLI ---------------------------------------------------------
+    typer.echo("# wbox CLI")
+    cli_version = _pkg_version("wealthbox-cli")
+    py_version = ".".join(str(v) for v in sys.version_info[:3])
+    binary = shutil.which("wbox") or "(not on PATH -running via python -m)"
+    typer.echo(f"  version:  {cli_version}")
+    typer.echo(f"  python:   {py_version} ({_platform_module.system()})")
+    typer.echo(f"  binary:   {binary}")
+
+    # --- Authentication ---------------------------------------------------
+    typer.echo("\n# Authentication")
+    config_path = _config_path()
+    if config_path.exists():
+        cfg = load_config()
+        cfg_token = cfg.get("token", "")
+        masked = f"...{cfg_token[-4:]}" if len(cfg_token) > 4 else "****"
+        typer.echo(f"  config:   {config_path} (present, masked: {masked})")
+    else:
+        typer.echo(f"  config:   {config_path} (not present)")
+    resolved_token, source = _detect_token_source(token)
+    typer.echo(f"  source:   {source}")
+    if not resolved_token:
+        typer.echo("  smoke:    skipped (no token)")
+        issues.append("token not configured - run 'wbox config set-token'")
+    else:
+        from wealthbox_tools.client import WealthboxAPIError
+
+        from ._util import run_client
+        try:
+            me = run_client(token, lambda c: c.get_me())
+            accounts = me.get("accounts") or []
+            firm_name = accounts[0].get("name") if accounts else "(no firm)"
+            typer.echo(
+                f"  smoke:    OK /me returned {me.get('name')} "
+                f"({firm_name}, user {me.get('id')})"
+            )
+        except WealthboxAPIError as e:
+            typer.echo(f"  smoke:    FAILED token rejected by /me: {e}")
+            issues.append("token rejected by /me - check it's still valid")
+        except Exception as e:
+            typer.echo(f"  smoke:    FAILED network/config error: {e}")
+            issues.append(f"smoke test failed: {e}")
+
+    # --- Agent CLIs -------------------------------------------------------
+    typer.echo("\n# Agent CLIs on PATH")
+    claude_path = shutil.which("claude") or shutil.which("claude.exe")
+    codex_path = shutil.which("codex") or shutil.which("codex.exe")
+    typer.echo(f"  claude:   {claude_path or 'not detected'}")
+    typer.echo(f"  codex:    {codex_path or 'not detected'}")
+
+    # --- Legacy skill installs --------------------------------------------
+    typer.echo("\n# Skill installs (legacy template-copy)")
+    for p in detect_platforms():
+        status = "installed" if is_installed(p) else "not installed"
+        meta = read_meta(skill_dir(p)) if is_installed(p) else {}
+        template_v = (meta.get("template") or {}).get("cli_version", "-")
+        upgrade_hint = ""
+        if template_v not in ("-", cli_version):
+            upgrade_hint = f"  [upgrade: {template_v} -> {cli_version}]"
+            issues.append(
+                f"{p.id} skill template is {template_v}, latest is {cli_version} "
+                f"- run 'wbox skills upgrade'"
+            )
+        typer.echo(
+            f"  {p.id:<22} {status:<16} template={template_v:<10} {skill_dir(p)}{upgrade_hint}"
+        )
+
+    # --- Plugin installs --------------------------------------------------
+    plugin_installs = detect_plugin_installs()
+    typer.echo("\n# Plugin installs (managed by host CLI: claude/codex plugin)")
+    if not plugin_installs:
+        typer.echo("  (none detected)")
+    else:
+        for pi in plugin_installs:
+            typer.echo(
+                f"  {pi.host:<22} plugin@{pi.marketplace:<18} "
+                f"version={pi.version:<10} {pi.skill_dir}"
+            )
+
+    # --- Firm data --------------------------------------------------------
+    typer.echo("\n# Firm data (canonical)")
+    typer.echo(f"  path:     {firm_dir()}")
+    typer.echo(f"  meta:     {firm_meta_path()}")
+    firm_meta = read_firm_meta()
+    if not firm_meta:
+        typer.echo("  state:    not bootstrapped")
+        issues.append("firm data not bootstrapped - run 'wbox skills bootstrap'")
+    else:
+        identity = firm_meta.get("identity") or {}
+        if firm_meta.get("onboarded_at"):
+            firm_state = "onboarded"
+        else:
+            firm_state = "bootstrapped (qualitative pending)"
+            issues.append(
+                "firm onboarding incomplete - open the skill in your agent to "
+                "walk through bootstrap.md (it'll call 'wbox skills mark-onboarded')"
+            )
+        typer.echo(f"  state:    {firm_state}")
+        typer.echo(f"  firm:     {identity.get('name', '-')}")
+        typer.echo(f"  user:     {identity.get('user_name', '-')}")
+        if firm_dir().exists():
+            md_files = sorted(p.name for p in firm_dir().glob("*.md"))
+            generated_set = set((firm_meta.get("files") or {}).keys())
+            handed = [f for f in md_files if f not in generated_set and not f.startswith("_")]
+            typer.echo(
+                f"  files:    {len(md_files)} markdown ({len(generated_set)} generated, "
+                f"{len(handed)} hand-edited)"
+            )
+            file_ts = list((firm_meta.get("files") or {}).values())
+            if file_ts:
+                try:
+                    oldest = min(datetime.fromisoformat(t).date() for t in file_ts)
+                    typer.echo(f"  oldest:   {oldest}")
+                except (ValueError, TypeError):
+                    pass
+
+    # --- Summary ----------------------------------------------------------
+    typer.echo("\n# Summary")
+    if not issues:
+        typer.echo("  All checks passed.")
+        return 0
+    typer.echo(f"  {len(issues)} issue(s) found:")
+    for i in issues:
+        typer.echo(f"    ! {i}")
+    return 1
+
+
+def _ensure_firm_migrated():
+    """Migrate legacy firm/ data on first read (idempotent)."""
+    installed = [skill_dir(p) for p in detect_platforms() if is_installed(p)]
+    return migrate_legacy_firm(installed)
+
+
+def doctor_cmd(
+    token: str | None = typer.Option(
+        None, "--token",
+        help="Override the API token for the smoke test. Overrides env var, config, .env.",
+    ),
+) -> None:
+    """Run the comprehensive doctor.
+
+    Always exits 0 — issues are surfaced in the Summary section. The doctor
+    is informational, not a CI gate. (A future --strict flag could change
+    this for scripting.) Token is intentionally NOT bound to
+    `envvar=WEALTHBOX_TOKEN` so the doctor can report whether the token came
+    from the flag, env var, config file, or .env file.
+    """
+    run_doctor(token=token)

--- a/src/wealthbox_tools/cli/main.py
+++ b/src/wealthbox_tools/cli/main.py
@@ -8,6 +8,7 @@ from .activity import app as activity_app
 from .categories import app as categories_app
 from .config import app as config_app
 from .contacts import app as contacts_app
+from .doctor import doctor_cmd as _doctor_cmd
 from .events import app as events_app
 from .households import app as households_app
 from .me import app as me_app
@@ -33,6 +34,12 @@ def _main(
     if version:
         typer.echo(_pkg_version("wealthbox-cli"))
         raise typer.Exit()
+
+
+app.command(
+    "doctor",
+    help="Comprehensive health check: CLI version, auth, agent CLIs, skills, plugins, firm.",
+)(_doctor_cmd)
 
 
 app.add_typer(activity_app, name="activity")

--- a/src/wealthbox_tools/cli/skills.py
+++ b/src/wealthbox_tools/cli/skills.py
@@ -14,7 +14,7 @@ from ._skill_bootstrap import (
     read_meta,
     update_template_meta,
 )
-from ._skill_paths import firm_dir, firm_meta_path
+from ._skill_paths import firm_dir
 from ._skill_platforms import (
     Platform,
     SkillInstallError,
@@ -286,70 +286,23 @@ def upgrade_cmd(
             typer.echo(f"OK upgraded {t.id}: {existing} -> {current}")
 
 
-@app.command("doctor", help="Diagnose install state and token.")
+@app.command(
+    "doctor",
+    help="Diagnose install state, auth, and firm data. Alias of `wbox doctor`.",
+)
 def doctor_cmd(
-    token: str | None = typer.Option(None, envvar="WEALTHBOX_TOKEN", hidden=True),
+    token: str | None = typer.Option(
+        None, "--token",
+        help="Override the API token for the smoke test.",
+    ),
 ) -> None:
-    from wealthbox_tools.client import WealthboxAPIError
-
-    from ._util import run_client
-
-    migrated_from = _ensure_firm_migrated()
-    if migrated_from is not None:
-        typer.echo(f"! migrated legacy firm/ data from {migrated_from} to {firm_dir()}")
-
-    current = _pkg_version("wealthbox-cli")
-    typer.echo("# Skill install state (legacy template-copy)")
-    for p in detect_platforms():
-        status = "installed" if is_installed(p) else "not installed"
-        meta = read_meta(skill_dir(p)) if is_installed(p) else {}
-        template_v = (meta.get("template") or {}).get("cli_version", "-")
-        upgrade_hint = ""
-        if template_v not in ("-", current):
-            upgrade_hint = f"  [upgrade available: {template_v} -> {current}]"
-        typer.echo(
-            f"  {p.id:<22} {status:<16} template={template_v:<10} {skill_dir(p)}{upgrade_hint}"
-        )
-
-    plugin_installs = detect_plugin_installs()
-    typer.echo("\n# Plugin installs (managed by host CLI: claude/codex plugin)")
-    if not plugin_installs:
-        typer.echo("  (none detected)")
-    else:
-        for pi in plugin_installs:
-            typer.echo(
-                f"  {pi.host:<22} {('plugin@' + pi.marketplace):<24} "
-                f"version={pi.version:<10} {pi.skill_dir}"
-            )
-
-    typer.echo("\n# Firm data (canonical)")
-    firm_meta = read_firm_meta()
-    if not firm_meta:
-        firm_state = "not bootstrapped"
-    elif firm_meta.get("onboarded_at"):
-        firm_state = "onboarded"
-    else:
-        firm_state = "bootstrapped (qualitative pending)"
-    identity = firm_meta.get("identity") or {}
-    typer.echo(f"  state:     {firm_state}")
-    typer.echo(f"  firm:      {identity.get('name', '-')}")
-    typer.echo(f"  user:      {identity.get('user_name', '-')}")
-    typer.echo(f"  path:      {firm_dir()}")
-    typer.echo(f"  meta:      {firm_meta_path()}")
-
-    typer.echo("\n# Token")
-    try:
-        me = run_client(token, lambda c: c.get_me())
-        accounts = me.get("accounts") or []
-        firm_name = accounts[0].get("name") if accounts else "(no firm)"
-        typer.echo(
-            f"  token ok - authenticated as {me.get('name')} "
-            f"(firm: {firm_name}, user id={me.get('id')})"
-        )
-    except WealthboxAPIError as e:
-        typer.echo(f"  token failed: {e}")
-    except Exception as e:  # network, config, etc.
-        typer.echo(f"  token check failed: {e}")
+    # `wbox skills doctor` is the older entry point; `wbox doctor` is the
+    # canonical top-level form. Both call the same function so the output
+    # never drifts. Token is intentionally not bound to envvar= so the
+    # doctor can report whether the token came from the flag, env var,
+    # config file, or .env file.
+    from .doctor import run_doctor
+    run_doctor(token=token)
 
 
 @app.command(

--- a/src/wealthbox_tools/cli/skills.py
+++ b/src/wealthbox_tools/cli/skills.py
@@ -19,6 +19,7 @@ from ._skill_platforms import (
     Platform,
     SkillInstallError,
     detect_platforms,
+    detect_plugin_installs,
     install_skill,
     is_installed,
     skill_dir,
@@ -43,7 +44,7 @@ def _ensure_firm_migrated() -> Path | None:
     return migrate_legacy_firm(installed)
 
 
-@app.command("list", help="Show where the skill is installed per platform.")
+@app.command("list", help="Show every skill copy on this machine: legacy installs and plugin-managed.")
 def list_platforms() -> None:
     _ensure_firm_migrated()
     firm_meta = read_firm_meta()
@@ -55,7 +56,7 @@ def list_platforms() -> None:
             last_bootstrap = max(files_map.values())
         onboarded = firm_meta.get("onboarded_at") or "no"
 
-    header = ("platform", "path", "status", "template-version")
+    header = ("source", "path", "status", "version")
     rows: list[tuple[str, str, str, str]] = []
     for p in detect_platforms():
         dest = skill_dir(p)
@@ -68,6 +69,13 @@ def list_platforms() -> None:
             str(dest),
             "installed" if installed else "not installed",
             template_version,
+        ))
+    for pi in detect_plugin_installs():
+        rows.append((
+            f"plugin:{pi.host}",
+            str(pi.skill_dir),
+            f"plugin@{pi.marketplace}",
+            pi.version,
         ))
 
     widths = [
@@ -291,7 +299,7 @@ def doctor_cmd(
         typer.echo(f"! migrated legacy firm/ data from {migrated_from} to {firm_dir()}")
 
     current = _pkg_version("wealthbox-cli")
-    typer.echo("# Skill install state")
+    typer.echo("# Skill install state (legacy template-copy)")
     for p in detect_platforms():
         status = "installed" if is_installed(p) else "not installed"
         meta = read_meta(skill_dir(p)) if is_installed(p) else {}
@@ -302,6 +310,17 @@ def doctor_cmd(
         typer.echo(
             f"  {p.id:<22} {status:<16} template={template_v:<10} {skill_dir(p)}{upgrade_hint}"
         )
+
+    plugin_installs = detect_plugin_installs()
+    typer.echo("\n# Plugin installs (managed by host CLI: claude/codex plugin)")
+    if not plugin_installs:
+        typer.echo("  (none detected)")
+    else:
+        for pi in plugin_installs:
+            typer.echo(
+                f"  {pi.host:<22} {('plugin@' + pi.marketplace):<24} "
+                f"version={pi.version:<10} {pi.skill_dir}"
+            )
 
     typer.echo("\n# Firm data (canonical)")
     firm_meta = read_firm_meta()

--- a/tests/test_doctor_cli.py
+++ b/tests/test_doctor_cli.py
@@ -1,0 +1,139 @@
+"""Tests for the top-level `wbox doctor` command.
+
+`wbox skills doctor` is an alias of `wbox doctor` — both call run_doctor()
+under the hood, so functional checks live in test_skills_cli_doctor.py.
+This file pins the section ordering and the new fields surfaced by the
+top-level command (CLI version, agent CLI detection, token source label,
+summary line).
+"""
+from __future__ import annotations
+
+import httpx
+import respx
+
+from wealthbox_tools.cli.main import app
+
+_BASE = "https://api.crmworkspace.com/v1"
+
+
+def _mock_me(name: str = "Adv", firm_id: int = 100, firm_name: str = "Firm") -> None:
+    respx.get(f"{_BASE}/me").mock(
+        return_value=httpx.Response(
+            200, json={"id": 1, "name": name, "accounts": [{"id": firm_id, "name": firm_name}]}
+        )
+    )
+
+
+@respx.mock
+def test_doctor_top_level_command_exists(runner, tmp_path, monkeypatch):
+    """`wbox doctor` (top-level) is registered and runs successfully."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    monkeypatch.chdir(tmp_path)
+    _mock_me()
+
+    result = runner.invoke(app, ["doctor"])
+    assert result.exit_code == 0, result.stdout
+
+
+@respx.mock
+def test_doctor_includes_all_sections(runner, tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    monkeypatch.chdir(tmp_path)
+    _mock_me()
+
+    result = runner.invoke(app, ["doctor"])
+    out = result.stdout
+    assert "# wbox CLI" in out
+    assert "# Authentication" in out
+    assert "# Agent CLIs on PATH" in out
+    assert "# Skill installs" in out
+    assert "# Plugin installs" in out
+    assert "# Firm data" in out
+    assert "# Summary" in out
+
+
+@respx.mock
+def test_doctor_reports_cli_version_and_python(runner, tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    monkeypatch.chdir(tmp_path)
+    _mock_me()
+
+    result = runner.invoke(app, ["doctor"])
+    out = result.stdout
+    assert "version:" in out
+    assert "python:" in out
+
+
+@respx.mock
+def test_doctor_token_source_reports_env_var(runner, tmp_path, monkeypatch):
+    """Token comes from WEALTHBOX_TOKEN (set by autouse mock_token fixture)."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    monkeypatch.chdir(tmp_path)
+    _mock_me()
+
+    result = runner.invoke(app, ["doctor"])
+    assert "env var" in result.stdout.lower() or "WEALTHBOX_TOKEN" in result.stdout
+
+
+@respx.mock
+def test_doctor_token_source_reports_flag(runner, tmp_path, monkeypatch):
+    """When --token is passed, source should be reported as the flag."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    monkeypatch.chdir(tmp_path)
+    _mock_me()
+
+    result = runner.invoke(app, ["doctor", "--token", "explicit-flag-token"])
+    assert "--token flag" in result.stdout
+
+
+@respx.mock
+def test_doctor_summary_lists_issues_when_firm_not_bootstrapped(runner, tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    monkeypatch.chdir(tmp_path)
+    _mock_me()
+
+    result = runner.invoke(app, ["doctor"])
+    # No bootstrap has run -> firm-not-bootstrapped issue should appear.
+    assert "issue(s) found" in result.stdout
+    assert "firm data not bootstrapped" in result.stdout
+
+
+@respx.mock
+def test_doctor_summary_clean_when_everything_set(runner, tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    monkeypatch.chdir(tmp_path)
+    _mock_me()
+
+    # Pre-seed canonical firm meta with onboarded_at so the doctor sees a
+    # fully healthy state.
+    from wealthbox_tools.cli._skill_paths import firm_meta_path
+    firm_meta_path().parent.mkdir(parents=True, exist_ok=True)
+    firm_meta_path().write_text(
+        '{"identity": {"id": 1, "name": "Firm", "user_id": 1, "user_name": "Adv"}, '
+        '"cli_version": "1.2.0", '
+        '"files": {"categories.md": "2026-05-01T00:00:00+00:00"}, '
+        '"onboarded_at": "2026-05-02T00:00:00+00:00"}'
+    )
+
+    result = runner.invoke(app, ["doctor"])
+    assert "All checks passed" in result.stdout
+
+
+@respx.mock
+def test_skills_doctor_alias_calls_same_function(runner, tmp_path, monkeypatch):
+    """`wbox skills doctor` and `wbox doctor` produce identical output."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    monkeypatch.chdir(tmp_path)
+    _mock_me()
+
+    a = runner.invoke(app, ["doctor"])
+    b = runner.invoke(app, ["skills", "doctor"])
+    assert a.stdout == b.stdout

--- a/tests/test_skill_platforms.py
+++ b/tests/test_skill_platforms.py
@@ -166,3 +166,87 @@ def test_uninstall_refuses_nonstandard_path(tmp_path):
         uninstall_skill(platform)
     # Outside is untouched
     assert (outside / "important.txt").exists()
+
+
+# --------------------------------------------------------------------------- #
+# Plugin install discovery                                                     #
+# --------------------------------------------------------------------------- #
+
+from wealthbox_tools.cli._skill_platforms import detect_plugin_installs  # noqa: E402
+
+
+def _make_plugin_install(cache_root: Path, marketplace: str, version: str) -> Path:
+    """Lay out <cache_root>/<marketplace>/wealthbox-crm/<version>/skills/wealthbox-crm/SKILL.md."""
+    skill_dir = cache_root / marketplace / "wealthbox-crm" / version / "skills" / "wealthbox-crm"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("# hello\n")
+    return skill_dir
+
+
+def test_detect_plugin_installs_empty_when_no_caches(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    monkeypatch.chdir(tmp_path)
+    assert detect_plugin_installs() == []
+
+
+def test_detect_plugin_installs_finds_claude_code_user(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    monkeypatch.chdir(tmp_path)
+    cache = tmp_path / ".claude" / "plugins" / "cache"
+    expected = _make_plugin_install(cache, "massive-value", "1.2.0")
+    installs = detect_plugin_installs()
+    assert len(installs) == 1
+    pi = installs[0]
+    assert pi.host == "claude-code-user"
+    assert pi.marketplace == "massive-value"
+    assert pi.version == "1.2.0"
+    assert pi.skill_dir == expected
+
+
+def test_detect_plugin_installs_finds_codex(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    monkeypatch.chdir(tmp_path)
+    cache = tmp_path / ".codex" / "plugins" / "cache"
+    _make_plugin_install(cache, "openai", "0.9.0")
+    installs = detect_plugin_installs()
+    assert [pi.host for pi in installs] == ["codex"]
+
+
+def test_detect_plugin_installs_finds_project_scope(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path / "home"))
+    project = tmp_path / "project"
+    project.mkdir()
+    monkeypatch.chdir(project)
+    cache = project / ".claude" / "plugins" / "cache"
+    _make_plugin_install(cache, "massive-value", "1.2.0")
+    installs = detect_plugin_installs()
+    assert [pi.host for pi in installs] == ["claude-code-project"]
+
+
+def test_detect_plugin_installs_returns_multiple_versions(monkeypatch, tmp_path):
+    """A user may have multiple cached versions (claude code keeps old
+    versions for rollback). Discovery surfaces every match."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    monkeypatch.chdir(tmp_path)
+    cache = tmp_path / ".claude" / "plugins" / "cache"
+    _make_plugin_install(cache, "massive-value", "1.1.6")
+    _make_plugin_install(cache, "massive-value", "1.2.0")
+    versions = sorted(pi.version for pi in detect_plugin_installs())
+    assert versions == ["1.1.6", "1.2.0"]
+
+
+def test_detect_plugin_installs_skips_dirs_without_skill_md(monkeypatch, tmp_path):
+    """A version dir without skills/wealthbox-crm/SKILL.md isn't a plugin install."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    monkeypatch.chdir(tmp_path)
+    cache = tmp_path / ".claude" / "plugins" / "cache"
+    incomplete = cache / "massive-value" / "wealthbox-crm" / "1.2.0"
+    incomplete.mkdir(parents=True)
+    # No skills/wealthbox-crm/SKILL.md
+    assert detect_plugin_installs() == []

--- a/tests/test_skills_cli_doctor.py
+++ b/tests/test_skills_cli_doctor.py
@@ -21,7 +21,7 @@ def test_doctor_reports_not_installed(runner, tmp_path, monkeypatch):
     result = runner.invoke(app, ["skills", "doctor"])
     assert result.exit_code == 0
     assert "not installed" in result.stdout.lower()
-    assert "token ok" in result.stdout.lower()
+    assert "/me returned" in result.stdout.lower()  # smoke test passed
 
 
 @respx.mock

--- a/tests/test_skills_lifecycle.py
+++ b/tests/test_skills_lifecycle.py
@@ -73,11 +73,11 @@ def test_full_lifecycle(runner, tmp_path, monkeypatch):
     assert r.exit_code == 0
     assert str(fd) in r.stdout
 
-    # doctor — green
+    # doctor (informational, exits 0 even when warnings are present)
     r = runner.invoke(app, ["skills", "doctor"])
     assert r.exit_code == 0, r.stdout
     assert "installed" in r.stdout.lower()
-    assert "token ok" in r.stdout.lower()
+    assert "/me returned" in r.stdout.lower()  # smoke test passed
 
     # uninstall (firm/ at canonical is preserved)
     r = runner.invoke(app, ["skills", "uninstall", "--yes"])


### PR DESCRIPTION
Two related diagnostics improvements that came out of the marketplace smoke test on Windows.

## 1. `wbox skills doctor` and `wbox skills list` detect plugin-installed skills

Before: both commands only checked the legacy install paths (`~/.claude/skills/`, `~/.codex/skills/`, `<cwd>/.claude/skills/`). A user who installed via `claude plugin install wealthbox-crm@massive-value` saw "not installed" everywhere even though the plugin was actively serving the skill.

After: `detect_plugin_installs()` scans `~/.claude/plugins/cache/.../wealthbox-crm/.../skills/wealthbox-crm/` (Claude Code user + project) and `~/.codex/plugins/cache/.../skills/wealthbox-crm/`. Results show up in a separate "Plugin installs (managed by host CLI: claude/codex plugin)" section. Source of truth for *which version is active* still lives in `claude plugin list` — we just stop pretending the plugin doesn't exist.

## 2. New top-level `wbox doctor` command

Single comprehensive health check at the CLI root, replacing the half-completeness of `wbox skills doctor`. Same logic, more sections, prettier layout. Both commands now call into a shared `run_doctor()` so output never drifts.

```
# wbox CLI
  version:  1.2.0
  python:   3.13.5 (Windows)
  binary:   ~/.local/bin/wbox.exe

# Authentication
  config:   ~/.config/wbox/config.json (present, masked: ...abc1)
  source:   env var (WEALTHBOX_TOKEN or .env)
  smoke:    OK /me returned Kadin Bullock (Squire Wealth Advisors, user 70416)

# Agent CLIs on PATH
  claude:   ~/.local/bin/claude.exe
  codex:    not detected

# Skill installs (legacy template-copy)
  claude-code-user       not installed    template=-          ...
  ...

# Plugin installs (managed by host CLI: claude/codex plugin)
  claude-code-user       plugin@massive-value      version=1.2.0      ...

# Firm data (canonical)
  state:    bootstrapped (qualitative pending)
  firm:     Squire Wealth Advisors
  files:    11 markdown (3 generated, 7 hand-edited)
  oldest:   2026-05-01

# Summary
  1 issue(s) found:
    ! firm onboarding incomplete - open the skill in your agent to walk through bootstrap.md
```

**New vs. existing**:
- wbox CLI section (version + Python + binary path) — new
- Authentication source detection (flag / env / config / .env) — new
- Agent CLIs on PATH (claude / codex) — new
- Plugin installs section (from change #1 above)
- Firm data file count + oldest timestamp — new
- Summary line listing every actionable issue — new

**Token source detection** required dropping `envvar=WEALTHBOX_TOKEN` from the Typer option — without it, `run_doctor()` can mirror `get_client`'s resolution order itself and report which layer the token actually came from.

**Exit code**: always 0. The doctor is informational, not a CI gate. A future `--strict` flag could change this for scripting use cases.

## Test plan
- 6 new tests for plugin-install discovery in `test_skill_platforms.py` (16 total)
- 8 new tests for the top-level `wbox doctor` in `test_doctor_cli.py`: section ordering, CLI version display, token-source detection (flag vs env), summary issue listing, clean-state output, and `wbox skills doctor` alias parity
- Updated 2 existing tests (`test_skills_cli_doctor.py`, `test_skills_lifecycle.py`) to look for the new "smoke OK /me returned" wording instead of the old "token ok"
- Live-verified on Kadin's machine: `wbox doctor` correctly shows the marketplace plugin install at v1.2.0, surfaces the firm-onboarding-incomplete warning, and reports the env-var token source

All 230 tests pass; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
