### PR TITLE
feat(tasks): top-level --category and --description flags

### DIFF
--- a/src/wealthbox_tools/cli/_util.py
+++ b/src/wealthbox_tools/cli/_util.py
@@ -416,6 +416,32 @@ def build_resource_filter(
     return result
 
 
+async def resolve_category_id(
+    client: WealthboxClient, category_type: CategoryType, value: str
+) -> int:
+    """Resolve a category name or numeric string to an integer ID.
+
+    If `value` is purely digits, returns int(value) without an API call.
+    Otherwise fetches all categories of the given type and case-insensitively
+    matches `name`. Raises typer.BadParameter on miss with available names.
+    """
+    if value.isdigit():
+        return int(value)
+    data = await client.list_all_categories(category_type)
+    items = data.get(category_type.value, [])
+    target = value.strip().casefold()
+    for item in items:
+        if str(item.get("name", "")).casefold() == target:
+            return int(item["id"])
+    available = sorted(str(i["name"]) for i in items if i.get("name"))
+    label = category_type.value.replace("_", " ")
+    if available:
+        raise typer.BadParameter(
+            f"Unknown {label} value '{value}'. Available: {', '.join(available)}"
+        )
+    raise typer.BadParameter(f"No {label} configured in this workspace.")
+
+
 def parse_more_fields(more_fields: str, reserved: set[str]) -> dict[str, Any]:
     """Parse --more-fields JSON and validate against reserved keys.
 

--- a/src/wealthbox_tools/cli/tasks.py
+++ b/src/wealthbox_tools/cli/tasks.py
@@ -25,6 +25,7 @@ from ._util import (
     make_resource_app,
     output_result,
     parse_more_fields,
+    resolve_category_id,
     run_client,
     run_client_with_comments,
     slim_comments,
@@ -47,7 +48,9 @@ _GET_JSON_FIELDS = [
     "category", "linked_to", "comments",
 ]
 
-_TASK_CREATE_RESERVED = {"name", "due_date", "frame", "priority", "assigned_to", "linked_to"}
+_TASK_CREATE_RESERVED = {
+    "name", "due_date", "frame", "priority", "assigned_to", "linked_to", "category", "description",
+}
 
 
 @app.command(
@@ -130,13 +133,18 @@ def add_task(
     ),
     frame: TaskFrame | None = typer.Option(None, "--frame", help="Friendly due timeframe"),
     priority: TaskPriority | None = typer.Option(None, "--priority", help="Low, Medium, or High"),
+    category: str | None = typer.Option(
+        None, "--category",
+        help="Task category by name or ID — see: wbox categories task-categories",
+    ),
+    description: str | None = typer.Option(None, "--description", help="Task description"),
     assigned_to: int | None = typer.Option(None, "--assigned-to", help="Assign to a user by ID"),
     contact: int | None = typer.Option(None, "--contact", help="Link to a Contact by ID"),
     project: int | None = typer.Option(None, "--project", help="Link to a Project by ID"),
     opportunity: int | None = typer.Option(None, "--opportunity", help="Link to an Opportunity by ID"),
     more_fields: str | None = typer.Option(
         None, "--more-fields",
-        help='JSON: {"category": 123, "complete": false, "assigned_to_team": 456, "description": "..."}',
+        help='JSON: {"complete": false, "assigned_to_team": 456}',
     ),
     token: str | None = typer.Option(None, envvar="WEALTHBOX_TOKEN", hidden=True),
     fmt: OutputFormat = typer.Option(OutputFormat.JSON, "--format"),
@@ -150,6 +158,7 @@ def add_task(
         "due_date": due_date,
         "frame": frame,
         "priority": priority,
+        "description": description,
         "assigned_to": assigned_to,
         "linked_to": build_linked_to(contact, project, opportunity),
     }
@@ -157,10 +166,14 @@ def add_task(
     if more_fields:
         payload.update(parse_more_fields(more_fields, _TASK_CREATE_RESERVED))
 
-    # Strip None before model construction (due_date XOR frame validator needs clean input)
-    input_model = TaskCreateInput(**{k: v for k, v in payload.items() if v is not None})
+    async def _create(client):  # type: ignore[no-untyped-def]
+        if category is not None:
+            payload["category"] = await resolve_category_id(client, CategoryType.TASK_CATEGORIES, category)
+        # Strip None before model construction (due_date XOR frame validator needs clean input)
+        clean = {k: v for k, v in payload.items() if v is not None}
+        return await client.create_task(TaskCreateInput(**clean))
 
-    output_result(run_client(token, lambda c: c.create_task(input_model)), fmt)
+    output_result(run_client(token, _create), fmt)
 
 
 @app.command("update", help="Update an existing task. Pass only the fields you want to change.")
@@ -171,6 +184,10 @@ def update_task(
     due_date: str | None = typer.Option(None, "--due-date", help="ISO 8601 datetime, e.g. '2026-04-01T09:00:00-07:00'"),
     frame: TaskFrame | None = typer.Option(None, "--frame", help="Friendly due timeframe"),
     priority: TaskPriority | None = typer.Option(None, "--priority", help="Low, Medium, or High"),
+    category: str | None = typer.Option(
+        None, "--category",
+        help="Task category by name or ID — see: wbox categories task-categories",
+    ),
     assigned_to: int | None = typer.Option(None, "--assigned-to", help="Reassign to a user by ID"),
     complete: bool | None = typer.Option(None, "--complete/--no-complete", help="Mark as complete or incomplete"),
     description: str | None = typer.Option(None, "--description"),
@@ -193,9 +210,13 @@ def update_task(
     linked = build_linked_to(contact, project, opportunity)
     if linked is not None:
         payload["linked_to"] = linked
-    input_model = TaskUpdateInput(**payload)
 
-    output_result(run_client(token, lambda c: c.update_task(task_id, input_model)), fmt)
+    async def _update(client):  # type: ignore[no-untyped-def]
+        if category is not None:
+            payload["category"] = await resolve_category_id(client, CategoryType.TASK_CATEGORIES, category)
+        return await client.update_task(task_id, TaskUpdateInput(**payload))
+
+    output_result(run_client(token, _update), fmt)
 
 
 @app.command("delete", help="Delete a task by ID.")

--- a/src/wealthbox_tools/skills/wealthbox-crm/references/tasks.md
+++ b/src/wealthbox_tools/skills/wealthbox-crm/references/tasks.md
@@ -46,11 +46,13 @@ wbox tasks add <NAME> [OPTIONS]
 | `--due-date` | STR | Due date (XOR with --frame) |
 | `--frame` | today\|tomorrow\|this-week\|next-week\|this-month\|next-month\|... | Relative due date (XOR with --due-date) |
 | `--priority` | Low\|Medium\|High | Priority level |
+| `--category` | STR | Task category by name or ID (e.g. "Follow-up"). See `wbox categories task-categories`. |
+| `--description` | STR | Task description |
 | `--assigned-to` | INT | Assign to user ID |
 | `--contact` | INT | Link to contact |
 | `--project` | INT | Link to project |
 | `--opportunity` | INT | Link to opportunity |
-| `--more-fields` | JSON | e.g. `{"category": 123, "description": "..."}` |
+| `--more-fields` | JSON | e.g. `{"complete": false, "assigned_to_team": 456}` |
 | `--format` | json\|table\|csv\|tsv | Output format |
 
 **Note:** `--due-date` and `--frame` are mutually exclusive. Use `--frame` for relative dates.
@@ -67,6 +69,7 @@ wbox tasks update <ID> [OPTIONS]
 | `--due-date` | STR | Change due date |
 | `--frame` | STR | Change relative due date |
 | `--priority` | Low\|Medium\|High | Change priority |
+| `--category` | STR | Task category by name or ID. See `wbox categories task-categories`. |
 | `--assigned-to` | INT | Reassign |
 | `--complete` / `--no-complete` | flag | Mark complete/incomplete |
 | `--description` | STR | Update description |

--- a/tests/test_tasks_create.py
+++ b/tests/test_tasks_create.py
@@ -68,12 +68,12 @@ def test_add_task_more_fields_regression(runner) -> None:
         [
             "tasks", "add", "Send proposal",
             "--due-date", "2026-03-20T09:00:00-07:00",
-            "--more-fields", '{"category": 99}',
+            "--more-fields", '{"assigned_to_team": 456}',
         ],
     )
     assert result.exit_code == 0
     sent = json.loads(route.calls[0].request.content)
-    assert sent["category"] == 99
+    assert sent["assigned_to_team"] == 456
 
 
 def test_add_task_priority_in_more_fields_raises(runner) -> None:
@@ -87,6 +87,114 @@ def test_add_task_priority_in_more_fields_raises(runner) -> None:
     )
     assert result.exit_code != 0
     assert "priority" in result.output.lower() or "priority" in (result.stderr or "").lower()
+
+
+def test_add_task_category_in_more_fields_raises(runner) -> None:
+    result = runner.invoke(
+        app,
+        [
+            "tasks", "add", "Send proposal",
+            "--due-date", "2026-03-20T09:00:00-07:00",
+            "--more-fields", '{"category": 99}',
+        ],
+    )
+    assert result.exit_code != 0
+    assert "category" in result.output.lower() or "category" in (result.stderr or "").lower()
+
+
+@respx.mock
+def test_add_task_with_category_numeric(runner) -> None:
+    route = respx.post("https://api.crmworkspace.com/v1/tasks").mock(
+        return_value=httpx.Response(200, json=_TASK_RESPONSE)
+    )
+    # No mock for /categories — if the CLI calls it, respx will raise.
+    result = runner.invoke(
+        app,
+        [
+            "tasks", "add", "Send proposal",
+            "--due-date", "2026-03-20T09:00:00-07:00",
+            "--category", "173277",
+        ],
+    )
+    assert result.exit_code == 0
+    sent = json.loads(route.calls[0].request.content)
+    assert sent["category"] == 173277
+
+
+@respx.mock
+def test_add_task_with_category_name_resolves_to_id(runner) -> None:
+    respx.get("https://api.crmworkspace.com/v1/categories/task_categories").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "task_categories": [
+                    {"id": 100, "name": "Phone"},
+                    {"id": 173277, "name": "Follow-up"},
+                ],
+                "meta": {"total_count": 2},
+            },
+        )
+    )
+    route = respx.post("https://api.crmworkspace.com/v1/tasks").mock(
+        return_value=httpx.Response(200, json=_TASK_RESPONSE)
+    )
+    result = runner.invoke(
+        app,
+        [
+            "tasks", "add", "Send proposal",
+            "--due-date", "2026-03-20T09:00:00-07:00",
+            "--category", "follow-up",  # case-insensitive match
+        ],
+    )
+    assert result.exit_code == 0
+    sent = json.loads(route.calls[0].request.content)
+    assert sent["category"] == 173277
+
+
+@respx.mock
+def test_add_task_with_unknown_category_errors(runner) -> None:
+    respx.get("https://api.crmworkspace.com/v1/categories/task_categories").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "task_categories": [
+                    {"id": 100, "name": "Phone"},
+                    {"id": 173277, "name": "Follow-up"},
+                ],
+                "meta": {"total_count": 2},
+            },
+        )
+    )
+    result = runner.invoke(
+        app,
+        [
+            "tasks", "add", "Send proposal",
+            "--due-date", "2026-03-20T09:00:00-07:00",
+            "--category", "Bogus",
+        ],
+    )
+    assert result.exit_code != 0
+    out = result.output + (result.stderr or "")
+    assert "Bogus" in out
+    assert "Phone" in out and "Follow-up" in out
+
+
+@respx.mock
+def test_add_task_with_description(runner) -> None:
+    route = respx.post("https://api.crmworkspace.com/v1/tasks").mock(
+        return_value=httpx.Response(200, json=_TASK_RESPONSE)
+    )
+    result = runner.invoke(
+        app,
+        [
+            "tasks", "add", "Send proposal",
+            "--due-date", "2026-03-20T09:00:00-07:00",
+            "--description", "Send the Q2 proposal deck.",
+        ],
+    )
+    assert result.exit_code == 0
+    sent = json.loads(route.calls[0].request.content)
+    assert sent["description"] == "Send the Q2 proposal deck."
 
 
 def test_add_task_missing_due_date_and_frame(runner) -> None:

--- a/tests/test_tasks_update.py
+++ b/tests/test_tasks_update.py
@@ -94,3 +94,37 @@ def test_update_task_name_only_no_date_required(runner) -> None:
     assert result.exit_code == 0
     sent = json.loads(route.calls[0].request.content)
     assert sent == {"name": "New name"}
+
+
+@respx.mock
+def test_update_task_with_category_numeric(runner) -> None:
+    route = respx.put("https://api.crmworkspace.com/v1/tasks/5").mock(
+        return_value=httpx.Response(200, json=_TASK_RESPONSE)
+    )
+    result = runner.invoke(app, ["tasks", "update", "5", "--category", "173277"])
+    assert result.exit_code == 0
+    sent = json.loads(route.calls[0].request.content)
+    assert sent == {"category": 173277}
+
+
+@respx.mock
+def test_update_task_with_category_name_resolves_to_id(runner) -> None:
+    respx.get("https://api.crmworkspace.com/v1/categories/task_categories").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "task_categories": [
+                    {"id": 100, "name": "Phone"},
+                    {"id": 173277, "name": "Follow-up"},
+                ],
+                "meta": {"total_count": 2},
+            },
+        )
+    )
+    route = respx.put("https://api.crmworkspace.com/v1/tasks/5").mock(
+        return_value=httpx.Response(200, json=_TASK_RESPONSE)
+    )
+    result = runner.invoke(app, ["tasks", "update", "5", "--category", "Follow-up"])
+    assert result.exit_code == 0
+    sent = json.loads(route.calls[0].request.content)
+    assert sent == {"category": 173277}


### PR DESCRIPTION
## Summary

Closes #17. Promotes task `--category` and `--description` from `--more-fields` JSON into top-level flags on `wbox tasks add` (and `--category` on `wbox tasks update`).

`--category` accepts either a name (e.g. `Follow-up`) or a numeric ID. Names are resolved against `/categories/task_categories` via a new `resolve_category_id()` helper in `cli/_util.py` — case-insensitive match, errors with available names listed on miss. Numeric input bypasses the API call.

Both fields are now reserved against `--more-fields` override (matches the existing `priority` / `assigned_to` reservation pattern).

Before:
```
wbox tasks add "Follow-up call" --frame next_week --more-fields '{"category": 173277}' --contact 30776510
```
After:
```
wbox tasks add "Follow-up call" --frame next_week --category Follow-up --contact 30776510
```

- 6 new respx-mocked tests (numeric bypass, name match, unknown-name error, description, category-in-more-fields rejection, update with name resolution)
- Skill reference doc (`references/tasks.md`) updated to surface the new flags
- Existing `--more-fields` regression test re-pointed to `assigned_to_team` since `category` is now reserved

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `pytest` — 239/239 pass
- [x] `wbox tasks add --help` and `wbox tasks update --help` show the new flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)