### PR TITLE
fix(comments): align --no-comments code and docs

### DIFF
--- a/codex-skill/wealthbox-crm/references/contacts.md
+++ b/codex-skill/wealthbox-crm/references/contacts.md
@@ -36,7 +36,7 @@ wbox contacts <ID>
 wbox contacts get <ID>
 ```
 
-Returns full contact record including comments (use `--no-comments` to omit).
+Returns the full contact record. Contacts do not carry comments in Wealthbox — to read comments, fetch the related task, note, event, opportunity, project, or workflow with its `get` command (those default to including comments and accept `--no-comments` to suppress).
 
 ## Create Contact
 

--- a/plugins/wealthbox-crm/skills/wealthbox-crm/references/contacts.md
+++ b/plugins/wealthbox-crm/skills/wealthbox-crm/references/contacts.md
@@ -36,7 +36,7 @@ wbox contacts <ID>
 wbox contacts get <ID>
 ```
 
-Returns full contact record including comments (use `--no-comments` to omit).
+Returns the full contact record. Contacts do not carry comments in Wealthbox — to read comments, fetch the related task, note, event, opportunity, project, or workflow with its `get` command (those default to including comments and accept `--no-comments` to suppress).
 
 ## Create Contact
 

--- a/src/wealthbox_tools/skills/wealthbox-crm/references/contacts.md
+++ b/src/wealthbox_tools/skills/wealthbox-crm/references/contacts.md
@@ -36,7 +36,7 @@ wbox contacts <ID>
 wbox contacts get <ID>
 ```
 
-Returns full contact record including comments (use `--no-comments` to omit).
+Returns the full contact record. Contacts do not carry comments in Wealthbox — to read comments, fetch the related task, note, event, opportunity, project, or workflow with its `get` command (those default to including comments and accept `--no-comments` to suppress).
 
 ## Create Contact
 


### PR DESCRIPTION
## Summary

Fixes #21. The skill reference for `wbox contacts get` advertised a `--no-comments` flag that does not (and should not) exist — Wealthbox's `/comments` endpoint does not accept Contact as a `resource_type`, so contacts simply do not carry comments. The doc was misleading the agent into trying a flag that errors out.

## Audit (code vs. docs)

| Resource      | Code has `--no-comments`?         | Docs claim `--no-comments`?       | Status before this PR |
|---------------|-----------------------------------|-----------------------------------|-----------------------|
| tasks         | yes (`cli/tasks.py:106`)          | yes (`references/tasks.md:35`)    | aligned               |
| events        | yes (`cli/events.py:84`)          | yes (`references/events.md:32`)   | aligned               |
| notes         | yes (`cli/notes.py:64`)           | yes (`references/notes.md:29`)    | aligned               |
| opportunities | yes (`cli/opportunities.py:97`)   | yes (`references/opportunities.md:31`) | aligned          |
| projects      | yes (`cli/projects.py:50`)        | yes (`references/projects.md:27`) | aligned               |
| workflows     | yes (`cli/workflows.py:78`)       | yes (`references/workflows.md:30`) | aligned              |
| **contacts**  | **no** (`cli/contacts.py:135-140`) | **yes** (`references/contacts.md:39`) | **mismatch — fixed here** |

Ground-truthed with `wbox <resource> get --help` — confirmed all six comment-bearing resources expose `--no-comments`, contacts does not.

`COMMENT_RESOURCE_TYPES` in `cli/_util.py` is the canonical list of resources that have comments, and Contact is (correctly) absent.

## Fix

- Rewrote the "Get Contact" section in `src/wealthbox_tools/skills/wealthbox-crm/references/contacts.md` to remove the false `--no-comments` claim and point readers at the comment-bearing resources instead.
- Re-ran `python scripts/sync-plugin.py` to mirror the canonical reference to `plugins/wealthbox-crm/skills/wealthbox-crm/` and `codex-skill/wealthbox-crm/`.

No code changes — the implementation is already correct; only the doc was lying.

## Note on the inverted-default `--with-comments` reference

The project-local `CLAUDE.md` (gitignored, line 100) describes the flag as `get --with-comments`, but the real flag is `--no-comments` (default-on, opt-out). Since `CLAUDE.md` is gitignored project memory and not part of the public repo, it can't be fixed in this PR — flagging here so the maintainer can update their local copy. Suggested wording is in the commit body.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `pytest` — 239 passed
- [x] `wbox contacts get --help` — confirmed no `--no-comments` (matches new docs)
- [x] `wbox tasks get --help` (and events/notes/opportunities/projects/workflows) — confirmed `--no-comments` present (matches existing docs)
- [x] `python scripts/sync-plugin.py` re-run; mirror dirs in sync with source