### PR TITLE
feat(tasks): accept kebab-case --frame; document Sunday "next_week" quirk

### DIFF
--- a/src/wealthbox_tools/cli/tasks.py
+++ b/src/wealthbox_tools/cli/tasks.py
@@ -53,6 +53,32 @@ _TASK_CREATE_RESERVED = {
 }
 
 
+def _normalize_frame(value: str | None) -> TaskFrame | None:
+    """Accept both kebab-case and snake_case for --frame; return a TaskFrame.
+
+    The CLI uses kebab-case for every other multi-word value (--contact-type,
+    --assigned-to, etc.), so users naturally try `--frame next-week`. The API
+    requires snake_case (``next_week``); we normalize before validating.
+    """
+    if value is None:
+        return None
+    normalized = value.replace("-", "_").lower()
+    try:
+        return TaskFrame(normalized)
+    except ValueError as exc:
+        choices = ", ".join(repr(m.value) for m in TaskFrame)
+        raise typer.BadParameter(
+            f"{value!r} is not one of {choices}.",
+            param_hint="'--frame'",
+        ) from exc
+
+
+_FRAME_HELP = (
+    "Friendly due timeframe. One of: today, tomorrow, this-week / this_week, "
+    "next-week / next_week, future, specific."
+)
+
+
 @app.command(
     "list",
     help=(
@@ -131,7 +157,12 @@ def add_task(
     due_date: str | None = typer.Option(
         None, "--due-date", help="Example: '2025-05-24 10:00 AM -0700' (must match Wealthbox format)"
     ),
-    frame: TaskFrame | None = typer.Option(None, "--frame", help="Friendly due timeframe"),
+    frame: TaskFrame | None = typer.Option(
+        None, "--frame",
+        help=_FRAME_HELP,
+        parser=_normalize_frame,
+        metavar="FRAME",
+    ),
     priority: TaskPriority | None = typer.Option(None, "--priority", help="Low, Medium, or High"),
     category: str | None = typer.Option(
         None, "--category",
@@ -182,7 +213,12 @@ def update_task(
     task_id: int = typer.Argument(..., help="Task ID"),
     name: str | None = typer.Option(None, "--name", help="Task name"),
     due_date: str | None = typer.Option(None, "--due-date", help="ISO 8601 datetime, e.g. '2026-04-01T09:00:00-07:00'"),
-    frame: TaskFrame | None = typer.Option(None, "--frame", help="Friendly due timeframe"),
+    frame: TaskFrame | None = typer.Option(
+        None, "--frame",
+        help=_FRAME_HELP,
+        parser=_normalize_frame,
+        metavar="FRAME",
+    ),
     priority: TaskPriority | None = typer.Option(None, "--priority", help="Low, Medium, or High"),
     category: str | None = typer.Option(
         None, "--category",

--- a/src/wealthbox_tools/skills/wealthbox-crm/references/tasks.md
+++ b/src/wealthbox_tools/skills/wealthbox-crm/references/tasks.md
@@ -44,7 +44,7 @@ wbox tasks add <NAME> [OPTIONS]
 |------|------|-------------|
 | `<NAME>` | positional | Task name (required) |
 | `--due-date` | STR | Due date (XOR with --frame) |
-| `--frame` | today\|tomorrow\|this-week\|next-week\|this-month\|next-month\|... | Relative due date (XOR with --due-date) |
+| `--frame` | today\|tomorrow\|this-week\|next-week\|future\|specific | Relative due date (XOR with --due-date). Both kebab-case (`next-week`) and snake_case (`next_week`) are accepted. |
 | `--priority` | Low\|Medium\|High | Priority level |
 | `--category` | STR | Task category by name or ID (e.g. "Follow-up"). See `wbox categories task-categories`. |
 | `--description` | STR | Task description |
@@ -57,6 +57,8 @@ wbox tasks add <NAME> [OPTIONS]
 
 **Note:** `--due-date` and `--frame` are mutually exclusive. Use `--frame` for relative dates.
 
+**Note (Wealthbox quirk):** `--frame next_week` resolves on the API side to the Monday of the calendar week *after* today. **If today is Sunday, `next_week` is tomorrow** (Monday) — only one day away, not seven. Wealthbox treats Sunday as the last day of the current week. If precise control matters (e.g. an advisor said "next week" expecting 7+ days out), use `--due-date YYYY-MM-DDTHH:MM:SS-07:00` with an explicit date instead of `--frame`.
+
 ## Update Task
 
 ```bash
@@ -67,7 +69,7 @@ wbox tasks update <ID> [OPTIONS]
 |------|------|-------------|
 | `--name` | STR | Rename |
 | `--due-date` | STR | Change due date |
-| `--frame` | STR | Change relative due date |
+| `--frame` | STR | Change relative due date. Accepts kebab-case (`next-week`) or snake_case (`next_week`); see Note above re: Sunday boundary. |
 | `--priority` | Low\|Medium\|High | Change priority |
 | `--category` | STR | Task category by name or ID. See `wbox categories task-categories`. |
 | `--assigned-to` | INT | Reassign |

--- a/tests/test_tasks_create.py
+++ b/tests/test_tasks_create.py
@@ -197,6 +197,48 @@ def test_add_task_with_description(runner) -> None:
     assert sent["description"] == "Send the Q2 proposal deck."
 
 
+@respx.mock
+def test_add_task_with_frame_kebab_case(runner) -> None:
+    """--frame next-week (kebab) is accepted and normalized to next_week before sending."""
+    route = respx.post("https://api.crmworkspace.com/v1/tasks").mock(
+        return_value=httpx.Response(200, json=_TASK_RESPONSE)
+    )
+    result = runner.invoke(app, ["tasks", "add", "Follow up", "--frame", "next-week"])
+    assert result.exit_code == 0
+    sent = json.loads(route.calls[0].request.content)
+    assert sent["frame"] == "next_week"
+
+
+@respx.mock
+def test_add_task_with_frame_snake_case(runner) -> None:
+    """--frame next_week (snake) is also accepted, sent as-is."""
+    route = respx.post("https://api.crmworkspace.com/v1/tasks").mock(
+        return_value=httpx.Response(200, json=_TASK_RESPONSE)
+    )
+    result = runner.invoke(app, ["tasks", "add", "Follow up", "--frame", "next_week"])
+    assert result.exit_code == 0
+    sent = json.loads(route.calls[0].request.content)
+    assert sent["frame"] == "next_week"
+
+
+@respx.mock
+def test_add_task_with_frame_this_week_kebab(runner) -> None:
+    """Kebab normalization also works for this-week."""
+    route = respx.post("https://api.crmworkspace.com/v1/tasks").mock(
+        return_value=httpx.Response(200, json=_TASK_RESPONSE)
+    )
+    result = runner.invoke(app, ["tasks", "add", "Follow up", "--frame", "this-week"])
+    assert result.exit_code == 0
+    sent = json.loads(route.calls[0].request.content)
+    assert sent["frame"] == "this_week"
+
+
+def test_add_task_with_frame_invalid_value(runner) -> None:
+    """An invalid frame value still errors cleanly."""
+    result = runner.invoke(app, ["tasks", "add", "Follow up", "--frame", "bogus"])
+    assert result.exit_code != 0
+
+
 def test_add_task_missing_due_date_and_frame(runner) -> None:
     result = runner.invoke(app, ["tasks", "add", "Send proposal"])
     assert result.exit_code != 0

--- a/tests/test_tasks_update.py
+++ b/tests/test_tasks_update.py
@@ -108,6 +108,36 @@ def test_update_task_with_category_numeric(runner) -> None:
 
 
 @respx.mock
+def test_update_task_frame_kebab_case(runner) -> None:
+    """--frame next-week (kebab) on update normalizes to next_week before sending."""
+    route = respx.put("https://api.crmworkspace.com/v1/tasks/5").mock(
+        return_value=httpx.Response(200, json=_TASK_RESPONSE)
+    )
+    result = runner.invoke(app, ["tasks", "update", "5", "--frame", "next-week"])
+    assert result.exit_code == 0
+    sent = json.loads(route.calls[0].request.content)
+    assert sent == {"frame": "next_week"}
+
+
+@respx.mock
+def test_update_task_frame_snake_case(runner) -> None:
+    """--frame next_week (snake) on update is also accepted."""
+    route = respx.put("https://api.crmworkspace.com/v1/tasks/5").mock(
+        return_value=httpx.Response(200, json=_TASK_RESPONSE)
+    )
+    result = runner.invoke(app, ["tasks", "update", "5", "--frame", "next_week"])
+    assert result.exit_code == 0
+    sent = json.loads(route.calls[0].request.content)
+    assert sent == {"frame": "next_week"}
+
+
+def test_update_task_frame_invalid_value(runner) -> None:
+    """An invalid frame value on update errors cleanly."""
+    result = runner.invoke(app, ["tasks", "update", "5", "--frame", "bogus"])
+    assert result.exit_code != 0
+
+
+@respx.mock
 def test_update_task_with_category_name_resolves_to_id(runner) -> None:
     respx.get("https://api.crmworkspace.com/v1/categories/task_categories").mock(
         return_value=httpx.Response(


### PR DESCRIPTION
## Summary

Two small task-related fixes bundled together (both surfaced during the v1.3.0 marketplace agent flow validation on 2026-05-03).

- **#18 — kebab-case `--frame`.** Every other multi-word value in the CLI (`--contact-type`, `--assigned-to`, etc.) is kebab-case, but `--frame next-week` failed with an enum error because `TaskFrame` only accepted snake_case. Now both `next-week` and `next_week` work; the CLI normalizes to snake_case before sending to the API. Applied to both `tasks add` and `tasks update`.
- **#19 — Document the Sunday `next_week` quirk.** Wealthbox resolves `--frame next_week` to the Monday of the calendar week *after* today. When invoked on a Sunday, that's *tomorrow* — not seven days out, which is what an advisor saying "next week" usually means. Added a Note callout in `references/tasks.md` near the `--frame` documentation, with a recommendation to use explicit `--due-date` for precise control.

## Implementation

- `_normalize_frame()` in `cli/tasks.py` — small helper that does `value.replace("-", "_").lower()` then validates via `TaskFrame(...)`. Wired in as Typer's `parser=` on the `--frame` option for both `add_task` and `update_task`.
- Tests in `test_tasks_create.py` and `test_tasks_update.py` cover both forms (kebab + snake) and an invalid value, asserting the wire payload always sends snake_case.

## Test plan

- [x] `ruff check src/ tests/` clean
- [x] `pytest` 246 passed (3 new on add, 3 new on update)
- [x] `wbox tasks add --help` and `wbox tasks update --help` show clean `--frame FRAME` help text listing both forms
- [x] Manual: `wbox tasks add Foo --frame next-week` and `--frame next_week` both work; `--frame bogus` still errors

Closes #18.
Closes #19.

Generated with [Claude Code](https://claude.com/claude-code)