### PR TITLE
fix: address Codex review findings from PRs #13, #14, #15

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -174,4 +174,7 @@ finally {
         Write-Host "Press Enter to close this window..." -ForegroundColor DarkGray
     }
     try { $null = Read-Host } catch { Start-Sleep -Seconds 30 }
+    # Surface failure to callers (CI wrappers, `powershell -File ...`,
+    # bootstrap scripts) so they can detect install failures via exit code.
+    if ($state -eq 'errored') { exit 1 }
 }

--- a/src/wealthbox_tools/cli/doctor.py
+++ b/src/wealthbox_tools/cli/doctor.py
@@ -32,11 +32,19 @@ def _detect_token_source(token_arg: str | None) -> tuple[str | None, str]:
         return token_arg, "--token flag"
     env_token = os.environ.get("WEALTHBOX_TOKEN")
     if env_token:
-        return env_token, "env var (WEALTHBOX_TOKEN or .env)"
+        return env_token, "env var (WEALTHBOX_TOKEN)"
     cfg = load_config()
     cfg_token = cfg.get("token")
     if cfg_token:
         return cfg_token, f"config file ({_config_path()})"
+    try:
+        from dotenv import load_dotenv
+        load_dotenv()
+        dotenv_token = os.environ.get("WEALTHBOX_TOKEN")
+        if dotenv_token:
+            return dotenv_token, ".env file in working directory"
+    except ImportError:
+        pass
     return None, "not set"
 
 

--- a/src/wealthbox_tools/cli/skills.py
+++ b/src/wealthbox_tools/cli/skills.py
@@ -143,6 +143,11 @@ def install_cmd(
         )
         raise typer.Exit(code=2)
 
+    # Migrate before installing: install_skill(force=True) deletes the
+    # existing skill dir (including any legacy <skill_dir>/firm/) before
+    # the copy. Migrating first preserves pre-1.2 firm data on upgrade.
+    _ensure_firm_migrated()
+
     with as_file(files("wealthbox_tools").joinpath("skills/wealthbox-crm")) as src:
         for target in targets:
             try:
@@ -152,8 +157,6 @@ def install_cmd(
                 raise typer.Exit(code=1) from e
             update_template_meta(skill_dir(target), cli_version=_pkg_version("wealthbox-cli"))
             typer.echo(f"OK installed to {skill_dir(target)}")
-
-    _ensure_firm_migrated()
 
     if not no_bootstrap:
         if typer.confirm("Run 'wbox skills bootstrap' now?", default=True):
@@ -347,6 +350,10 @@ def uninstall_cmd(
     platforms_flag: list[str] = typer.Option([], "--platform", "-p"),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation."),
 ) -> None:
+    # Migrate before removing: pre-1.2 installs still have firm/ inside the
+    # skill dir, so uninstall_skill() would wipe it without this step.
+    _ensure_firm_migrated()
+
     if platforms_flag:
         targets = _resolve_platforms(platforms_flag)
     else:


### PR DESCRIPTION
## Summary

Reviewed every Codex comment on recent PRs and resolved the four still-applicable findings in a single fix commit. Two were obsolete and one is a false positive — see "Status of every Codex finding" below.

- **PR #15 (P1)** `cli/doctor.py:_detect_token_source` — added the `.env` fallback so `wbox doctor` matches `get_client`'s resolution order. Previously it returned "not set" before trying python-dotenv, falsely reporting `token not configured` when only a `.env` file supplied the token.
- **PR #14 (P2)** `scripts/install.ps1` — surface a non-zero exit code from `finally` when `$state -eq 'errored'`, so `powershell -File ...` callers, CI wrappers, and bootstrap scripts can detect installer failures.
- **PR #13 (P1)** `cli/skills.py:install_cmd` — moved `_ensure_firm_migrated()` ahead of the install loop. `install_skill(force=True)` deletes the existing skill dir (including pre-1.2 `firm/`), so the previous order would wipe firm data before migration could copy it.
- **PR #13 (P1)** `cli/skills.py:uninstall_cmd` — added `_ensure_firm_migrated()` at the top, so the help text's "firm data is preserved" guarantee holds for pre-1.2 layouts too.

## Status of every Codex finding

| PR | Finding | Status |
|---|---|---|
| #15 | `_detect_token_source` skips `.env` | Fixed |
| #14 | install.ps1 exits 0 on caught error | Fixed |
| #13 | install_cmd migrates firm after `--force` destroys it | Fixed |
| #13 | uninstall_cmd never migrates firm | Fixed |
| #12 | README `\|` in inline code | False positive — `\|` is GFM-required to escape pipes in table cells; the rendered README on github.com copies as a working pipeline |
| #7  | sync doesn't copy `_meta.json.firm` section | Obsolete — `wbox skills sync` was removed when firm data became machine-level |
| #6  | sync target/source path equality only checks IDs | Obsolete — same |

## Test plan

- [x] `ruff check src/ tests/` clean
- [x] `pytest` 272 passed
- [ ] Manual: `wbox doctor` with only a `.env`-supplied token correctly reports the `.env` source and runs the `/me` smoke test
- [ ] Manual: `wbox skills install --force` preserves a pre-1.2 `<skill_dir>/firm/` payload at the canonical machine path
- [ ] Manual: `wbox skills uninstall` preserves a pre-1.2 `<skill_dir>/firm/` payload
- [ ] Manual: PowerShell `install.ps1` exits non-zero when `uv tool install` fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)