### PR TITLE
feat: wbox firm export end-to-end (#31)

### DIFF
--- a/src/wealthbox_tools/cli/firm.py
+++ b/src/wealthbox_tools/cli/firm.py
@@ -1,0 +1,42 @@
+"""``wbox firm`` — firm-archive operations."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+
+from ..firm import pack as _pack
+from ._skill_paths import firm_dir as _firm_dir
+
+app = typer.Typer(
+    context_settings={"help_option_names": ["-h", "--help"]},
+    help="Firm-archive export/import operations.",
+    no_args_is_help=True,
+)
+
+
+@app.command("export")
+def export_firm(
+    out: Path = typer.Option(
+        Path("firm.zip"),
+        "--out",
+        "-o",
+        help="Path to write the firm archive zip. Defaults to ./firm.zip.",
+    ),
+) -> None:
+    """Export the local firm directory as a portable zip archive.
+
+    Only hand-edited policy files and a small policy-shaped subset of
+    ``_meta.json`` are included. Generated files (``categories.md``,
+    ``custom-fields.md``, ``users.md``) and API-derived metadata
+    (refresh timestamps, ``cli_version``) are excluded by construction.
+    """
+    src = _firm_dir()
+    if not src.is_dir():
+        raise typer.BadParameter(
+            f"Firm directory not found at {src}. Run 'wbox skills bootstrap' first."
+        )
+    blob = _pack(src)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_bytes(blob)
+    typer.echo(f"Wrote {out} ({len(blob)} bytes).", err=True)

--- a/src/wealthbox_tools/cli/firm.py
+++ b/src/wealthbox_tools/cli/firm.py
@@ -7,6 +7,7 @@ import typer
 
 from ..firm import pack as _pack
 from ._skill_paths import firm_dir as _firm_dir
+from .skills import _ensure_firm_migrated
 
 app = typer.Typer(
     context_settings={"help_option_names": ["-h", "--help"]},
@@ -31,6 +32,7 @@ def export_firm(
     ``custom-fields.md``, ``users.md``) and API-derived metadata
     (refresh timestamps, ``cli_version``) are excluded by construction.
     """
+    _ensure_firm_migrated()
     src = _firm_dir()
     if not src.is_dir():
         raise typer.BadParameter(

--- a/src/wealthbox_tools/cli/main.py
+++ b/src/wealthbox_tools/cli/main.py
@@ -11,6 +11,7 @@ from .config import app as config_app
 from .contacts import app as contacts_app
 from .doctor import doctor_cmd as _doctor_cmd
 from .events import app as events_app
+from .firm import app as firm_app
 from .households import app as households_app
 from .me import app as me_app
 from .notes import app as notes_app
@@ -56,6 +57,7 @@ app.add_typer(categories_app, name="categories")
 app.add_typer(config_app, name="config")
 app.add_typer(contacts_app, name="contacts")
 app.add_typer(events_app, name="events")
+app.add_typer(firm_app, name="firm")
 app.add_typer(households_app, name="households")
 app.add_typer(me_app, name="me")
 app.add_typer(notes_app, name="notes")

--- a/src/wealthbox_tools/firm/__init__.py
+++ b/src/wealthbox_tools/firm/__init__.py
@@ -1,0 +1,10 @@
+"""Firm-archive packaging.
+
+Public surface:
+- ``pack(firm_dir)`` — zip a firm directory into a portable byte blob.
+"""
+from __future__ import annotations
+
+from .archive import pack
+
+__all__ = ["pack"]

--- a/src/wealthbox_tools/firm/archive.py
+++ b/src/wealthbox_tools/firm/archive.py
@@ -1,0 +1,133 @@
+"""Firm-archive packing.
+
+Produces a portable zip of a firm directory's hand-edited policy files plus
+a small manifest. The contract is **whitelist-only**: ``pack`` copies only
+the explicitly listed files into the archive — anything else in the source
+``firm_dir`` is silently dropped. This makes it impossible for generated
+files (``categories.md``, ``custom-fields.md``, ``users.md``), API-derived
+``_meta.json`` fields (refresh timestamps, ``cli_version``), or ad-hoc
+debris in the firm directory to leak into the export.
+
+The user preferences directory (``~/.config/wbox/user/``) is never reachable
+from this module by construction: ``pack`` only sees ``firm_dir``.
+"""
+from __future__ import annotations
+
+import io
+import json
+import zipfile
+from datetime import datetime, timezone
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
+from pathlib import Path
+from typing import Any
+
+#: Manifest schema version. Bump on backwards-incompatible changes.
+FORMAT_VERSION = 1
+
+#: Hand-edited firm-policy markdown files that are included in the archive.
+#: This is the canonical whitelist — adding a new resource here is a
+#: deliberate, reviewable change.
+HAND_EDITED_FILES: tuple[str, ...] = (
+    "contacts.md",
+    "tasks.md",
+    "notes.md",
+    "events.md",
+    "opportunities.md",
+    "projects.md",
+    "workflows.md",
+)
+
+#: The ``_meta.json`` keys that survive the pack. Anything else (identity
+#: cache, ``cli_version``, per-file refresh timestamps) is API-derived and
+#: regenerated on import; it must not travel with the archive.
+META_POLICY_KEYS: tuple[str, ...] = ("onboarded_at",)
+
+
+def _cli_version() -> str:
+    try:
+        return _pkg_version("wealthbox-cli")
+    except PackageNotFoundError:
+        # The package is always installed in normal use; fall back to a
+        # sentinel so tests in unusual environments still get a manifest.
+        return "0+unknown"
+
+
+def _read_meta_policy(firm_dir: Path) -> tuple[dict[str, Any], str | None]:
+    """Return ``(policy_subset, source_firm_name)`` from ``_meta.json``.
+
+    The subset contains only :data:`META_POLICY_KEYS`. ``source_firm_name``
+    is read out of the (otherwise discarded) ``identity`` block so the
+    manifest can record it without leaking the rest of the cache.
+    """
+    meta_path = firm_dir / "_meta.json"
+    if not meta_path.exists():
+        return {}, None
+    try:
+        loaded = json.loads(meta_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return {}, None
+    if not isinstance(loaded, dict):
+        return {}, None
+
+    policy: dict[str, Any] = {k: loaded[k] for k in META_POLICY_KEYS if k in loaded}
+    identity = loaded.get("identity")
+    source_firm_name: str | None = None
+    if isinstance(identity, dict):
+        name = identity.get("name")
+        if isinstance(name, str):
+            source_firm_name = name
+    return policy, source_firm_name
+
+
+def _build_manifest(
+    *,
+    exported_at: datetime,
+    source_firm_name: str | None,
+) -> dict[str, Any]:
+    return {
+        "format_version": FORMAT_VERSION,
+        "exported_at": exported_at.isoformat(),
+        "source_firm_name": source_firm_name,
+        "source_cli_version": _cli_version(),
+    }
+
+
+def pack(firm_dir: Path, *, now: datetime | None = None) -> bytes:
+    """Pack a firm directory into a zip blob.
+
+    Only the whitelisted hand-edited markdown files (:data:`HAND_EDITED_FILES`)
+    and the policy-shaped subset of ``_meta.json`` (:data:`META_POLICY_KEYS`)
+    are copied into the archive. Missing files are skipped silently — a firm
+    that has not yet authored a particular policy doc still produces a valid
+    archive.
+
+    Args:
+        firm_dir: Source firm directory (e.g. ``~/.config/wbox/firm``).
+        now: Override the ``exported_at`` timestamp. Defaults to
+            ``datetime.now(timezone.utc)``. Tests use this to pin output for
+            deterministic byte comparisons.
+
+    Returns:
+        The zip archive as raw bytes.
+    """
+    firm_dir = Path(firm_dir)
+    exported_at = now if now is not None else datetime.now(timezone.utc)
+
+    meta_policy, source_firm_name = _read_meta_policy(firm_dir)
+    manifest = _build_manifest(
+        exported_at=exported_at,
+        source_firm_name=source_firm_name,
+    )
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, mode="w", compression=zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr(".manifest.json", json.dumps(manifest, indent=2) + "\n")
+        if meta_policy:
+            zf.writestr("_meta.json", json.dumps(meta_policy, indent=2) + "\n")
+        for name in HAND_EDITED_FILES:
+            src = firm_dir / name
+            if not src.is_file():
+                continue
+            zf.writestr(name, src.read_text(encoding="utf-8"))
+    return buf.getvalue()

--- a/src/wealthbox_tools/firm/archive.py
+++ b/src/wealthbox_tools/firm/archive.py
@@ -127,7 +127,7 @@ def pack(firm_dir: Path, *, now: datetime | None = None) -> bytes:
             zf.writestr("_meta.json", json.dumps(meta_policy, indent=2) + "\n")
         for name in HAND_EDITED_FILES:
             src = firm_dir / name
-            if not src.is_file():
+            if src.is_symlink() or not src.is_file():
                 continue
             zf.writestr(name, src.read_text(encoding="utf-8"))
     return buf.getvalue()

--- a/tests/test_firm_export.py
+++ b/tests/test_firm_export.py
@@ -1,0 +1,215 @@
+"""Tests for ``wbox firm export`` and the underlying ``firm.archive.pack``."""
+from __future__ import annotations
+
+import io
+import json
+import zipfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from wealthbox_tools.cli.main import app
+from wealthbox_tools.firm.archive import HAND_EDITED_FILES, pack
+
+# --------------------------------------------------------------------------- #
+# Helpers                                                                      #
+# --------------------------------------------------------------------------- #
+
+
+def _populated_firm_dir(root: Path) -> dict[str, str]:
+    """Create a firm dir with one of every file we expect to encounter.
+
+    Returns a map of filename -> body for the hand-edited files so tests can
+    assert round-trip equality.
+    """
+    root.mkdir(parents=True, exist_ok=True)
+    bodies = {
+        "contacts.md": "# Contacts policy\n\nUse household-first onboarding.\n",
+        "tasks.md": "# Tasks policy\n\nDefault priority is medium.\n",
+        "notes.md": "# Notes policy\n",
+        "events.md": "# Events policy\n",
+        "opportunities.md": "# Opportunities policy\n",
+        "projects.md": "# Projects policy\n",
+        "workflows.md": "# Workflows policy\n",
+    }
+    for name, body in bodies.items():
+        (root / name).write_text(body, encoding="utf-8")
+
+    # Generated files (must be excluded).
+    (root / "categories.md").write_text("# generated categories\n", encoding="utf-8")
+    (root / "custom-fields.md").write_text("# generated custom fields\n", encoding="utf-8")
+    (root / "users.md").write_text("# generated users\n", encoding="utf-8")
+
+    # _meta.json with both API-derived junk and the policy subset.
+    (root / "_meta.json").write_text(
+        json.dumps(
+            {
+                "identity": {"id": 100, "name": "Test Firm", "user_id": 1},
+                "cli_version": "9.9.9",
+                "files": {
+                    "categories.md": "2024-01-01T00:00:00+00:00",
+                    "custom-fields.md": "2024-01-01T00:00:00+00:00",
+                    "users.md": "2024-01-01T00:00:00+00:00",
+                },
+                "onboarded_at": "2024-02-15T12:34:56+00:00",
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    return bodies
+
+
+def _names_in(blob: bytes) -> set[str]:
+    with zipfile.ZipFile(io.BytesIO(blob)) as zf:
+        return set(zf.namelist())
+
+
+def _read_in(blob: bytes, name: str) -> bytes:
+    with zipfile.ZipFile(io.BytesIO(blob)) as zf:
+        return zf.read(name)
+
+
+# --------------------------------------------------------------------------- #
+# Acceptance tests                                                             #
+# --------------------------------------------------------------------------- #
+
+
+def test_pack_round_trips_hand_edited_files(tmp_path: Path) -> None:
+    """Round-trip — hand-edited files arrive byte-for-byte after unzip."""
+    firm = tmp_path / "firm"
+    bodies = _populated_firm_dir(firm)
+
+    blob = pack(firm, now=datetime(2026, 1, 1, tzinfo=timezone.utc))
+
+    for name, expected in bodies.items():
+        assert _read_in(blob, name).decode("utf-8") == expected
+
+
+def test_pack_excludes_generated_files_and_meta_api_fields(tmp_path: Path) -> None:
+    """Generated files and API-derived ``_meta.json`` keys are excluded."""
+    firm = tmp_path / "firm"
+    _populated_firm_dir(firm)
+
+    blob = pack(firm, now=datetime(2026, 1, 1, tzinfo=timezone.utc))
+    names = _names_in(blob)
+
+    # Generated files must not appear.
+    assert "categories.md" not in names
+    assert "custom-fields.md" not in names
+    assert "users.md" not in names
+
+    # _meta.json IS included, but only with the policy subset.
+    assert "_meta.json" in names
+    meta = json.loads(_read_in(blob, "_meta.json"))
+    assert meta == {"onboarded_at": "2024-02-15T12:34:56+00:00"}
+    assert "identity" not in meta
+    assert "cli_version" not in meta
+    assert "files" not in meta
+
+
+def test_pack_does_not_include_user_prefs_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The user-prefs dir is unreachable from ``pack`` by construction.
+
+    We mock a populated ``~/.config/wbox/user/`` and assert the resulting
+    archive contains nothing under a ``user/`` path.
+    """
+    fake_home = tmp_path / "home"
+    user_dir = fake_home / ".config" / "wbox" / "user"
+    user_dir.mkdir(parents=True)
+    (user_dir / "preferences.md").write_text("# secret prefs\n", encoding="utf-8")
+    monkeypatch.setenv("HOME", str(fake_home))
+    monkeypatch.setenv("USERPROFILE", str(fake_home))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(fake_home / ".config"))
+    monkeypatch.setenv("APPDATA", str(fake_home / ".config"))
+
+    firm = tmp_path / "firm"
+    _populated_firm_dir(firm)
+
+    blob = pack(firm, now=datetime(2026, 1, 1, tzinfo=timezone.utc))
+    names = _names_in(blob)
+
+    assert not any(n.startswith("user/") for n in names)
+    assert "preferences.md" not in names
+
+
+def test_pack_manifest_has_format_version_one(tmp_path: Path) -> None:
+    firm = tmp_path / "firm"
+    _populated_firm_dir(firm)
+
+    blob = pack(firm, now=datetime(2026, 1, 1, tzinfo=timezone.utc))
+
+    manifest = json.loads(_read_in(blob, ".manifest.json"))
+    assert manifest["format_version"] == 1
+    assert manifest["exported_at"] == "2026-01-01T00:00:00+00:00"
+    assert manifest["source_firm_name"] == "Test Firm"
+    # Must come from the installed package metadata, not be empty.
+    assert isinstance(manifest["source_cli_version"], str)
+    assert manifest["source_cli_version"]
+
+
+# --------------------------------------------------------------------------- #
+# Whitelist regression                                                         #
+# --------------------------------------------------------------------------- #
+
+
+def test_pack_silently_drops_unexpected_files(tmp_path: Path) -> None:
+    """Whitelist enforcement: a stray file in firm_dir does NOT appear in the zip.
+
+    This guards against accidental blacklist regressions — if someone adds a
+    new generated file in the future, ``pack`` keeps excluding it without
+    needing the exclusion list updated.
+    """
+    firm = tmp_path / "firm"
+    _populated_firm_dir(firm)
+    (firm / "surprise.md").write_text("# I should not be in the zip\n", encoding="utf-8")
+    (firm / "secret.json").write_text('{"leak": true}\n', encoding="utf-8")
+
+    blob = pack(firm, now=datetime(2026, 1, 1, tzinfo=timezone.utc))
+    names = _names_in(blob)
+
+    assert "surprise.md" not in names
+    assert "secret.json" not in names
+
+    # Sanity: the expected whitelist is what survived (plus manifest + meta).
+    assert {".manifest.json", "_meta.json"} <= names
+    for name in HAND_EDITED_FILES:
+        assert name in names
+
+
+# --------------------------------------------------------------------------- #
+# CLI                                                                          #
+# --------------------------------------------------------------------------- #
+
+
+def test_firm_export_cli_writes_zip(
+    runner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The autouse isolate_config_dir fixture redirects firm_dir() under tmp_path.
+    from wealthbox_tools.cli._skill_paths import firm_dir
+
+    fd = firm_dir()
+    _populated_firm_dir(fd)
+
+    out = tmp_path / "firm.zip"
+    result = runner.invoke(app, ["firm", "export", "--out", str(out)])
+
+    assert result.exit_code == 0, result.stdout
+    assert out.exists()
+    blob = out.read_bytes()
+    names = _names_in(blob)
+    assert ".manifest.json" in names
+    assert "contacts.md" in names
+    assert "categories.md" not in names
+
+
+def test_firm_export_cli_errors_when_firm_dir_missing(
+    runner, tmp_path: Path
+) -> None:
+    out = tmp_path / "firm.zip"
+    result = runner.invoke(app, ["firm", "export", "--out", str(out)])
+    assert result.exit_code != 0
+    assert not out.exists()

--- a/tests/test_firm_export.py
+++ b/tests/test_firm_export.py
@@ -213,3 +213,31 @@ def test_firm_export_cli_errors_when_firm_dir_missing(
     result = runner.invoke(app, ["firm", "export", "--out", str(out)])
     assert result.exit_code != 0
     assert not out.exists()
+
+
+def test_pack_skips_symlinked_policy_files(tmp_path: Path) -> None:
+    """Reject symlinked policy files so they cannot leak content from outside firm_dir.
+
+    The whitelist trusts that ``firm_dir / name`` is a regular file under the
+    firm directory. A symlink — even one pointing within firm_dir — could
+    redirect to ``~/.config/wbox/user/preferences.md`` or other host content,
+    breaking the "user prefs unreachable" guarantee. ``pack`` skips them.
+    """
+    firm = tmp_path / "firm"
+    _populated_firm_dir(firm)
+
+    # Replace contacts.md with a symlink pointing at a file outside firm_dir.
+    outside = tmp_path / "outside.md"
+    outside.write_text("# leaked secret content\n", encoding="utf-8")
+    (firm / "contacts.md").unlink()
+    try:
+        (firm / "contacts.md").symlink_to(outside)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks not supported on this platform/test environment")
+
+    blob = pack(firm, now=datetime(2026, 1, 1, tzinfo=timezone.utc))
+    names = _names_in(blob)
+
+    assert "contacts.md" not in names
+    # Other whitelisted files still present.
+    assert "tasks.md" in names


### PR DESCRIPTION
## Summary

First Module A tracer — implements the firm-archive export path end-to-end.

- New `src/wealthbox_tools/firm/archive.py` with public `pack(firm_dir: Path) -> bytes`. Whitelist-only: copies the seven hand-edited policy markdown files (`contacts.md`, `tasks.md`, `notes.md`, `events.md`, `opportunities.md`, `projects.md`, `workflows.md`) and a policy-shaped subset of `_meta.json` (just `onboarded_at`). Manifest carries `format_version: 1`, `exported_at`, `source_firm_name`, `source_cli_version`.
- New `wbox firm export --out <path>` (default `./firm.zip`) wired through a new `firm` sub-app in `cli/main.py`.
- `exported_at` accepts a `now=` clock injection so tests can pin output for byte-stable comparisons.
- `source_cli_version` is read via `importlib.metadata.version("wealthbox-cli")`, matching `cli/main.py`, `cli/doctor.py`, `_skill_bootstrap.py`.

### Schema decisions

- **Whitelist enforcement, not blacklist.** The `HAND_EDITED_FILES` tuple is the canonical pack list. `categories.md`, `custom-fields.md`, `users.md`, ad-hoc debris in `firm_dir`, and the user-prefs directory (`~/.config/wbox/user/`) are all excluded by virtue of not appearing in the whitelist — there is no exclusion list to drift.
- **`_meta.json` is included but filtered.** Only `META_POLICY_KEYS = ("onboarded_at",)` survives the pack. The API-derived `identity`, `cli_version`, and `files` (refresh timestamps) are dropped — they are regenerated on import. `source_firm_name` is read out of the discarded `identity` block before discard, recorded in the manifest only.
- **User directory is unreachable from `pack` by construction.** `pack` only sees `firm_dir`; the user-prefs path is never built, never opened, never iterated.

## Test plan

- [x] `python -m pytest tests/test_firm_export.py -q` — 7 passed (round-trip, generated-file exclusion, user-prefs exclusion, manifest version, whitelist regression for stray files, CLI write, CLI error when firm dir missing)
- [x] Full suite `pytest -q` — 279 passed
- [x] `ruff check src/ tests/` — clean

## Notes for reviewer

- May conflict with #30 on `cli/main.py` sub-app registration — trivial to resolve (one alphabetized `add_typer` line + one import).

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)