### PR TITLE
feat: skill-ref regen tracer for contacts (#30)

### DIFF
--- a/src/wealthbox_tools/cli/internals.py
+++ b/src/wealthbox_tools/cli/internals.py
@@ -1,0 +1,35 @@
+"""Hidden ``wbox internals`` sub-app for repo maintenance commands.
+
+Commands here are not part of the public CLI surface; they are excluded
+from ``wbox --help`` via ``hidden=True`` and exist for tasks like
+regenerating skill reference docs from the live Typer command tree.
+"""
+from __future__ import annotations
+
+import typer
+
+from wealthbox_tools.internals.skill_ref_gen import regenerate_all
+
+app = typer.Typer(
+    context_settings={"help_option_names": ["-h", "--help"]},
+    help="Repo-maintenance commands (hidden from --help).",
+    no_args_is_help=True,
+    hidden=True,
+)
+
+
+@app.command(
+    "regen-skill-refs",
+    help="Regenerate flag tables in skill reference markdown files from the Typer command tree.",
+    hidden=True,
+)
+def regen_skill_refs() -> None:
+    result = regenerate_all()
+    for path in result.modified:
+        typer.echo(f"updated {path}")
+    for path in result.skipped_no_markers:
+        typer.echo(f"skipped (no markers) {path}", err=True)
+    for path in result.missing:
+        typer.echo(f"missing {path}", err=True)
+    if not result.modified:
+        typer.echo("no changes")

--- a/src/wealthbox_tools/cli/main.py
+++ b/src/wealthbox_tools/cli/main.py
@@ -13,6 +13,7 @@ from .doctor import doctor_cmd as _doctor_cmd
 from .events import app as events_app
 from .firm import app as firm_app
 from .households import app as households_app
+from .internals import app as internals_app
 from .me import app as me_app
 from .notes import app as notes_app
 from .opportunities import app as opportunities_app
@@ -59,6 +60,7 @@ app.add_typer(contacts_app, name="contacts")
 app.add_typer(events_app, name="events")
 app.add_typer(firm_app, name="firm")
 app.add_typer(households_app, name="households")
+app.add_typer(internals_app, name="internals", hidden=True)
 app.add_typer(me_app, name="me")
 app.add_typer(notes_app, name="notes")
 app.add_typer(opportunities_app, name="opportunities")

--- a/src/wealthbox_tools/internals/__init__.py
+++ b/src/wealthbox_tools/internals/__init__.py
@@ -1,0 +1,6 @@
+"""Internal tooling shipped with the wealthbox-cli package.
+
+These modules are not part of the public CLI surface; they back the
+``wbox internals`` hidden sub-app and exist for repo maintenance
+(e.g. regenerating skill reference docs from the Typer command tree).
+"""

--- a/src/wealthbox_tools/internals/skill_ref_gen.py
+++ b/src/wealthbox_tools/internals/skill_ref_gen.py
@@ -334,7 +334,14 @@ def _rewrite_between_markers(content: str, new_block: str) -> str | None:
 # ---------------------------------------------------------------------------
 
 def _collect_commands_for_resource(resource: str) -> list[CommandInfo]:
-    """Return the leaf commands rooted at ``wbox <resource>``."""
+    """Return the leaf commands rooted at ``wbox <resource>``.
+
+    Raises:
+        KeyError: if ``resource`` is not registered under the root Typer app.
+            This catches typos and stale entries in
+            :data:`RESOURCE_REFERENCE_MAP` before we silently overwrite a
+            reference file with an empty flag block.
+    """
     from wealthbox_tools.cli.main import app as _root_app
 
     click_root = typer.main.get_command(_root_app)
@@ -342,7 +349,11 @@ def _collect_commands_for_resource(resource: str) -> list[CommandInfo]:
         return []
     sub = click_root.commands.get(resource)
     if sub is None:
-        return []
+        raise KeyError(
+            f"skill-ref auto-gen: resource {resource!r} is mapped in "
+            "RESOURCE_REFERENCE_MAP but not registered on the root Typer app. "
+            "Fix the map entry or register the sub-app before regenerating."
+        )
     return _walk_commands(sub, path=(resource,))
 
 

--- a/src/wealthbox_tools/internals/skill_ref_gen.py
+++ b/src/wealthbox_tools/internals/skill_ref_gen.py
@@ -1,0 +1,389 @@
+"""Skill-reference markdown auto-generator.
+
+The wealthbox-crm skill ships per-resource reference markdown files under
+``src/wealthbox_tools/skills/wealthbox-crm/references/``. Each file contains
+hand-written editorial content (intro, examples, tips) interleaved with
+flag tables that must stay in lock-step with the Typer command surface.
+
+This module owns the flag tables. They are delimited in markdown by HTML
+comment markers so they survive markdown renderers without artifacts:
+
+    <!-- auto-gen:flags -->
+    ...generated content...
+    <!-- /auto-gen:flags -->
+
+``regenerate_all()`` walks the live Typer command tree, looks up the
+markdown file for each top-level resource in :data:`RESOURCE_REFERENCE_MAP`,
+and rewrites everything between the markers. Editorial content outside the
+markers is never touched. Files lacking the markers are left alone with a
+one-line warning to stderr.
+
+The output is **deterministic**: commands and flags are sorted, choice
+lists are sorted, and a regenerated tree produces a byte-identical diff on
+a second pass.
+"""
+from __future__ import annotations
+
+import enum
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import click
+import typer
+
+# ---------------------------------------------------------------------------
+# Public types
+# ---------------------------------------------------------------------------
+
+OPEN_MARKER = "<!-- auto-gen:flags -->"
+CLOSE_MARKER = "<!-- /auto-gen:flags -->"
+
+
+@dataclass
+class ChangeSet:
+    """Result of a regeneration pass.
+
+    ``modified`` lists absolute paths of files whose contents changed on
+    disk. ``skipped_no_markers`` lists paths that exist but lack the
+    auto-gen markers (a warning was already printed to stderr). ``missing``
+    lists paths that were expected but not found on disk.
+    """
+
+    modified: list[Path] = field(default_factory=list)
+    skipped_no_markers: list[Path] = field(default_factory=list)
+    missing: list[Path] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Resource → markdown file mapping
+# ---------------------------------------------------------------------------
+
+#: Top-level Typer sub-app name → reference markdown filename (relative to
+#: the references directory). Slice #30 covers `contacts` only; subsequent
+#: issues will extend this map.
+RESOURCE_REFERENCE_MAP: dict[str, str] = {
+    "contacts": "contacts.md",
+}
+
+
+def _references_dir() -> Path:
+    """Return the absolute path to the references/ directory in this checkout."""
+    # internals/ is a sibling of skills/. Walk up to the wealthbox_tools
+    # package root and then into the skill's references dir.
+    return (
+        Path(__file__).resolve().parent.parent
+        / "skills"
+        / "wealthbox-crm"
+        / "references"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Click introspection
+# ---------------------------------------------------------------------------
+
+@dataclass
+class FlagInfo:
+    """A single CLI flag, normalised for rendering.
+
+    All fields are pre-formatted strings except ``choices`` which carries
+    the sorted list of valid enum values (empty for non-enum flags).
+    """
+
+    primary: str          # e.g. "--first-name"
+    aliases: tuple[str, ...]  # e.g. ("-v",) — sorted, primary excluded
+    type_label: str       # e.g. "TEXT", "INTEGER", "BOOLEAN", "Gender"
+    description: str      # Typer help text, single-line
+    default: str          # rendered default ("-" when no default)
+    choices: tuple[str, ...]  # sorted enum values, empty if not an enum
+
+
+@dataclass
+class CommandInfo:
+    """A single CLI command and its flags."""
+
+    path: tuple[str, ...]      # ("contacts", "add", "person")
+    synopsis: str              # one-line help/short_help
+    flags: tuple[FlagInfo, ...]
+
+
+def _is_hidden(cmd: click.Command) -> bool:
+    return bool(getattr(cmd, "hidden", False))
+
+
+def _walk_commands(
+    cmd: click.Command,
+    path: tuple[str, ...] = (),
+) -> list[CommandInfo]:
+    """Recursively collect non-hidden leaf commands from a Click command tree."""
+    if _is_hidden(cmd):
+        return []
+    if isinstance(cmd, click.Group):
+        out: list[CommandInfo] = []
+        # Sort sub-command names for determinism.
+        for name in sorted(cmd.commands):
+            sub = cmd.commands[name]
+            out.extend(_walk_commands(sub, path + (name,)))
+        return out
+    return [_describe_command(cmd, path)]
+
+
+def _describe_command(cmd: click.Command, path: tuple[str, ...]) -> CommandInfo:
+    synopsis = (cmd.short_help or cmd.help or "").strip().splitlines()
+    synopsis_line = synopsis[0] if synopsis else ""
+
+    flags: list[FlagInfo] = []
+    for param in cmd.params:
+        if not isinstance(param, click.Option):
+            # Arguments are documented in the command synopsis, not the
+            # flag table.
+            continue
+        if param.hidden:
+            continue
+        flags.append(_describe_option(param))
+
+    # Sort flags alphabetically by primary flag name (case-insensitive),
+    # so the rendered table is deterministic.
+    flags.sort(key=lambda f: f.primary.lstrip("-").lower())
+    return CommandInfo(path=path, synopsis=synopsis_line, flags=tuple(flags))
+
+
+def _describe_option(opt: click.Option) -> FlagInfo:
+    long_opts = sorted([o for o in opt.opts if o.startswith("--")])
+    short_opts = sorted([o for o in opt.opts if o.startswith("-") and not o.startswith("--")])
+    if long_opts:
+        primary = long_opts[0]
+        rest_long = tuple(long_opts[1:])
+    elif short_opts:
+        primary = short_opts[0]
+        rest_long = ()
+    else:
+        primary = (opt.opts or ["?"])[0]
+        rest_long = ()
+
+    # Boolean negation flags ("--active/--inactive") show up in
+    # secondary_opts on Click; surface them as aliases so the doc reflects
+    # the negative form.
+    sec = sorted(getattr(opt, "secondary_opts", []) or [])
+
+    aliases = tuple(sorted(set(rest_long + tuple(short_opts) + tuple(sec)) - {primary}))
+
+    type_label, choices = _render_type(opt)
+    default = _render_default(opt)
+    description = (opt.help or "").strip().replace("\n", " ")
+    if description:
+        # Collapse runs of whitespace introduced by the newline replacement.
+        description = " ".join(description.split())
+
+    return FlagInfo(
+        primary=primary,
+        aliases=aliases,
+        type_label=type_label,
+        description=description,
+        default=default,
+        choices=tuple(choices),
+    )
+
+
+def _render_type(opt: click.Option) -> tuple[str, list[str]]:
+    """Return (type_label, sorted_enum_choices)."""
+    pt = opt.type
+    if isinstance(pt, click.Choice):
+        # Typer renders enum-typed Options via click.Choice.
+        choices = sorted(str(c) for c in pt.choices)
+        # Use a stable label distinct from raw "Choice" so readers can tell
+        # at a glance that this is an enum-bounded flag.
+        return ("CHOICE", choices)
+    if opt.is_flag or opt.count:
+        return ("BOOLEAN", [])
+    # Map common Click param types to the labels Typer prints.
+    name = getattr(pt, "name", None) or pt.__class__.__name__
+    label_map = {
+        "text": "TEXT",
+        "integer": "INTEGER",
+        "boolean": "BOOLEAN",
+        "float": "FLOAT",
+    }
+    return (label_map.get(name, name.upper()), [])
+
+
+def _render_default(opt: click.Option) -> str:
+    """Render the option default deterministically."""
+    if not opt.show_default and opt.default is None:
+        return "-"
+    default = opt.default
+    if callable(default):
+        try:
+            default = default()
+        except Exception:  # pragma: no cover - defensive
+            default = None
+    if default is None:
+        return "-"
+    if isinstance(default, bool):
+        return "true" if default else "false"
+    if isinstance(default, enum.Enum):
+        return str(default.value)
+    if isinstance(default, (list, tuple)):
+        if not default:
+            return "-"
+        return ", ".join(str(x) for x in default)
+    return str(default)
+
+
+# ---------------------------------------------------------------------------
+# Markdown rendering
+# ---------------------------------------------------------------------------
+
+def _render_block(commands: list[CommandInfo]) -> str:
+    """Render the body that lives between the auto-gen markers.
+
+    Output ends with a newline so a regenerated file ends cleanly. The
+    block is deterministic for a given input.
+    """
+    if not commands:
+        return ""
+    # Sort commands by full path for stable ordering.
+    commands = sorted(commands, key=lambda c: c.path)
+
+    chunks: list[str] = []
+    for cmd in commands:
+        chunks.append(_render_command(cmd))
+    # Single blank line between commands; trailing newline at the end.
+    return "\n".join(chunks).rstrip() + "\n"
+
+
+def _render_command(cmd: CommandInfo) -> str:
+    invocation = "wbox " + " ".join(cmd.path)
+    lines: list[str] = []
+    lines.append(f"### `{invocation}`")
+    lines.append("")
+    if cmd.synopsis:
+        lines.append(cmd.synopsis)
+        lines.append("")
+
+    if not cmd.flags:
+        lines.append("_No flags._")
+        lines.append("")
+        return "\n".join(lines)
+
+    lines.append("| Flag | Type | Default | Description |")
+    lines.append("|------|------|---------|-------------|")
+    enum_blocks: list[str] = []
+    for flag in cmd.flags:
+        flag_cell = f"`{flag.primary}`"
+        if flag.aliases:
+            flag_cell += " / " + " / ".join(f"`{a}`" for a in flag.aliases)
+        type_cell = f"`{flag.type_label}`"
+        default_cell = f"`{flag.default}`"
+        desc_cell = _escape_table_cell(flag.description) or ""
+        lines.append(f"| {flag_cell} | {type_cell} | {default_cell} | {desc_cell} |")
+        if flag.choices:
+            block = [f"**Choices for `{flag.primary}`:**", ""]
+            block.extend(f"- `{c}`" for c in flag.choices)
+            block.append("")
+            enum_blocks.append("\n".join(block))
+
+    lines.append("")
+    if enum_blocks:
+        lines.extend(enum_blocks)
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _escape_table_cell(text: str) -> str:
+    """Escape a description so it survives a markdown pipe-table cell."""
+    return text.replace("|", "\\|")
+
+
+# ---------------------------------------------------------------------------
+# File rewriting
+# ---------------------------------------------------------------------------
+
+def _rewrite_between_markers(content: str, new_block: str) -> str | None:
+    """Replace the content between the auto-gen markers.
+
+    Returns the rewritten content, or ``None`` if the markers are not
+    present (or are malformed) so the caller can warn and skip.
+    """
+    open_idx = content.find(OPEN_MARKER)
+    if open_idx == -1:
+        return None
+    close_idx = content.find(CLOSE_MARKER, open_idx + len(OPEN_MARKER))
+    if close_idx == -1:
+        return None
+
+    # Preserve everything up to and including the open marker line, replace
+    # the body, then resume at the close marker line. We always leave
+    # exactly one newline after the open marker and one blank line before
+    # the close marker to keep the diff stable.
+    before = content[: open_idx + len(OPEN_MARKER)]
+    after = content[close_idx:]
+
+    body = new_block.strip("\n")
+    if body:
+        middle = "\n" + body + "\n"
+    else:
+        middle = "\n"
+
+    return before + middle + after
+
+
+# ---------------------------------------------------------------------------
+# Public entrypoint
+# ---------------------------------------------------------------------------
+
+def _collect_commands_for_resource(resource: str) -> list[CommandInfo]:
+    """Return the leaf commands rooted at ``wbox <resource>``."""
+    from wealthbox_tools.cli.main import app as _root_app
+
+    click_root = typer.main.get_command(_root_app)
+    if not isinstance(click_root, click.Group):  # pragma: no cover - sanity
+        return []
+    sub = click_root.commands.get(resource)
+    if sub is None:
+        return []
+    return _walk_commands(sub, path=(resource,))
+
+
+def regenerate_all(*, references_dir: Path | None = None) -> ChangeSet:
+    """Regenerate every reference markdown file we know how to drive.
+
+    For each entry in :data:`RESOURCE_REFERENCE_MAP`, walk the Typer command
+    tree under that top-level resource, render the auto-gen block, and
+    write it into the corresponding markdown file between the auto-gen
+    markers. Editorial content outside the markers is preserved.
+
+    A file lacking the markers is left untouched and a one-line warning is
+    printed to stderr (it is recorded in :class:`ChangeSet.skipped_no_markers`).
+    Files listed in the map but missing on disk are recorded in
+    :class:`ChangeSet.missing` and skipped silently — adding the file is the
+    operator's job.
+    """
+    refs_dir = references_dir or _references_dir()
+    changeset = ChangeSet()
+
+    # Sort for deterministic warning order.
+    for resource in sorted(RESOURCE_REFERENCE_MAP):
+        target = refs_dir / RESOURCE_REFERENCE_MAP[resource]
+        if not target.exists():
+            changeset.missing.append(target)
+            continue
+        original = target.read_text(encoding="utf-8")
+
+        commands = _collect_commands_for_resource(resource)
+        new_block = _render_block(commands)
+        rewritten = _rewrite_between_markers(original, new_block)
+        if rewritten is None:
+            print(
+                f"warning: skill-ref auto-gen markers not found in {target}; "
+                "leaving file unchanged",
+                file=sys.stderr,
+            )
+            changeset.skipped_no_markers.append(target)
+            continue
+        if rewritten != original:
+            target.write_text(rewritten, encoding="utf-8")
+            changeset.modified.append(target)
+
+    return changeset

--- a/src/wealthbox_tools/skills/wealthbox-crm/references/contacts.md
+++ b/src/wealthbox_tools/skills/wealthbox-crm/references/contacts.md
@@ -136,6 +136,370 @@ wbox contacts categories website-types
 wbox contacts categories contact-roles
 ```
 
+## Generated Flag Reference
+
+The following section is auto-generated from the Typer command tree by
+`wbox internals regen-skill-refs`. Do not hand-edit between the markers —
+edits will be overwritten on the next regen pass.
+
+<!-- auto-gen:flags -->
+### `wbox contacts add household`
+
+Create a Household contact.
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--active` / `--inactive` | `BOOLEAN` | `-` | Set contact status to Active or Inactive |
+| `--assigned-to` | `INTEGER` | `-` | Assign to a user by ID |
+| `--contact-source` | `TEXT` | `-` |  |
+| `--contact-type` | `TEXT` | `-` | e.g. Client, Prospect |
+| `--email` | `TEXT` | `-` | Primary email address |
+| `--email-type` | `TEXT` | `-` | Email kind (e.g. Work, Personal) — see: wbox contacts categories email-types |
+| `--format` | `CHOICE` | `json` |  |
+| `--more-fields` | `TEXT` | `-` | Extra fields as JSON object (merged with flags; cannot override explicit flags) |
+| `--name` | `TEXT` | `-` | Household name (required) |
+| `--tags` | `TEXT` | `-` | Comma-separated tag names (e.g. 'VIP,Q1-Outreach'). New tags are auto-created. |
+
+**Choices for `--format`:**
+
+- `csv`
+- `json`
+- `table`
+- `tsv`
+
+### `wbox contacts add org`
+
+Create an Organization contact.
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--active` / `--inactive` | `BOOLEAN` | `-` | Set contact status to Active or Inactive |
+| `--assigned-to` | `INTEGER` | `-` | Assign to a user by ID |
+| `--contact-source` | `TEXT` | `-` |  |
+| `--contact-type` | `TEXT` | `-` | e.g. Client, Prospect |
+| `--email` | `TEXT` | `-` | Primary email address |
+| `--email-type` | `TEXT` | `-` | Email kind (e.g. Work, Personal) — see: wbox contacts categories email-types |
+| `--format` | `CHOICE` | `json` |  |
+| `--more-fields` | `TEXT` | `-` | Extra fields as JSON object (merged with flags; cannot override explicit flags) |
+| `--name` | `TEXT` | `-` | Organization name (required) |
+| `--phone` | `TEXT` | `-` | Primary phone number |
+| `--phone-type` | `TEXT` | `-` | Phone kind (e.g. Work, Mobile) — see: wbox contacts categories phone-types |
+| `--tags` | `TEXT` | `-` | Comma-separated tag names (e.g. 'VIP,Q1-Outreach'). New tags are auto-created. |
+
+**Choices for `--format`:**
+
+- `csv`
+- `json`
+- `table`
+- `tsv`
+
+### `wbox contacts add person`
+
+Create a Person contact.
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--active` / `--inactive` | `BOOLEAN` | `-` | Set contact status to Active or Inactive |
+| `--anniversary` | `TEXT` | `-` | Format: YYYY-MM-DD |
+| `--assigned-to` | `INTEGER` | `-` | Assign to a user by ID |
+| `--birth-date` | `TEXT` | `-` | Format: YYYY-MM-DD |
+| `--company-name` | `TEXT` | `-` |  |
+| `--contact-source` | `TEXT` | `-` |  |
+| `--contact-type` | `TEXT` | `-` | e.g. Client, Prospect |
+| `--email` | `TEXT` | `-` | Primary email address |
+| `--email-type` | `TEXT` | `-` | Email kind (e.g. Work, Personal) — see: wbox contacts categories email-types |
+| `--first-name` | `TEXT` | `-` |  |
+| `--format` | `CHOICE` | `json` |  |
+| `--gender` | `CHOICE` | `-` |  |
+| `--job-title` | `TEXT` | `-` |  |
+| `--last-name` | `TEXT` | `-` |  |
+| `--marital-status` | `CHOICE` | `-` |  |
+| `--middle-name` | `TEXT` | `-` |  |
+| `--more-fields` | `TEXT` | `-` | Extra fields as JSON object (merged with flags; cannot override explicit flags) |
+| `--nickname` | `TEXT` | `-` |  |
+| `--phone` | `TEXT` | `-` | Primary phone number |
+| `--phone-type` | `TEXT` | `-` | Phone kind (e.g. Work, Mobile) — see: wbox contacts categories phone-types |
+| `--prefix` | `TEXT` | `-` |  |
+| `--suffix` | `TEXT` | `-` |  |
+| `--tags` | `TEXT` | `-` | Comma-separated tag names (e.g. 'VIP,Q1-Outreach'). New tags are auto-created. |
+
+**Choices for `--format`:**
+
+- `csv`
+- `json`
+- `table`
+- `tsv`
+
+**Choices for `--gender`:**
+
+- `Female`
+- `Male`
+- `Non-binary`
+- `Unknown`
+
+**Choices for `--marital-status`:**
+
+- `Divorced`
+- `Life partner`
+- `Married`
+- `Separated`
+- `Single`
+- `Unknown`
+- `Widowed`
+
+### `wbox contacts add trust`
+
+Create a Trust contact.
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--active` / `--inactive` | `BOOLEAN` | `-` | Set contact status to Active or Inactive |
+| `--assigned-to` | `INTEGER` | `-` | Assign to a user by ID |
+| `--contact-source` | `TEXT` | `-` |  |
+| `--contact-type` | `TEXT` | `-` | e.g. Client, Prospect |
+| `--email` | `TEXT` | `-` | Primary email address |
+| `--email-type` | `TEXT` | `-` | Email kind (e.g. Work, Personal) — see: wbox contacts categories email-types |
+| `--format` | `CHOICE` | `json` |  |
+| `--more-fields` | `TEXT` | `-` | Extra fields as JSON object (merged with flags; cannot override explicit flags) |
+| `--name` | `TEXT` | `-` | Trust name (required) |
+| `--phone` | `TEXT` | `-` | Primary phone number |
+| `--phone-type` | `TEXT` | `-` | Phone kind (e.g. Work, Mobile) — see: wbox contacts categories phone-types |
+| `--tags` | `TEXT` | `-` | Comma-separated tag names (e.g. 'VIP,Q1-Outreach'). New tags are auto-created. |
+
+**Choices for `--format`:**
+
+- `csv`
+- `json`
+- `table`
+- `tsv`
+
+### `wbox contacts categories address-types`
+
+List address type options.
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--format` | `CHOICE` | `json` |  |
+| `--page` | `INTEGER` | `-` | Page number |
+| `--per-page` | `INTEGER` | `-` | Results per page (max 100) |
+
+**Choices for `--format`:**
+
+- `csv`
+- `json`
+- `table`
+- `tsv`
+
+### `wbox contacts categories contact-roles`
+
+List contact role options.
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--format` | `CHOICE` | `json` |  |
+| `--page` | `INTEGER` | `-` | Page number |
+| `--per-page` | `INTEGER` | `-` | Results per page (max 100) |
+
+**Choices for `--format`:**
+
+- `csv`
+- `json`
+- `table`
+- `tsv`
+
+### `wbox contacts categories contact-sources`
+
+List contact source options.
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--format` | `CHOICE` | `json` |  |
+| `--page` | `INTEGER` | `-` | Page number |
+| `--per-page` | `INTEGER` | `-` | Results per page (max 100) |
+
+**Choices for `--format`:**
+
+- `csv`
+- `json`
+- `table`
+- `tsv`
+
+### `wbox contacts categories contact-types`
+
+List contact type options.
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--format` | `CHOICE` | `json` |  |
+| `--page` | `INTEGER` | `-` | Page number |
+| `--per-page` | `INTEGER` | `-` | Results per page (max 100) |
+
+**Choices for `--format`:**
+
+- `csv`
+- `json`
+- `table`
+- `tsv`
+
+### `wbox contacts categories email-types`
+
+List email type options.
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--format` | `CHOICE` | `json` |  |
+| `--page` | `INTEGER` | `-` | Page number |
+| `--per-page` | `INTEGER` | `-` | Results per page (max 100) |
+
+**Choices for `--format`:**
+
+- `csv`
+- `json`
+- `table`
+- `tsv`
+
+### `wbox contacts categories phone-types`
+
+List phone type options.
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--format` | `CHOICE` | `json` |  |
+| `--page` | `INTEGER` | `-` | Page number |
+| `--per-page` | `INTEGER` | `-` | Results per page (max 100) |
+
+**Choices for `--format`:**
+
+- `csv`
+- `json`
+- `table`
+- `tsv`
+
+### `wbox contacts categories website-types`
+
+List website type options.
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--format` | `CHOICE` | `json` |  |
+| `--page` | `INTEGER` | `-` | Page number |
+| `--per-page` | `INTEGER` | `-` | Results per page (max 100) |
+
+**Choices for `--format`:**
+
+- `csv`
+- `json`
+- `table`
+- `tsv`
+
+### `wbox contacts delete`
+
+Delete an existing contact.
+
+_No flags._
+
+### `wbox contacts get`
+
+Get a single contact by ID.
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--format` | `CHOICE` | `json` |  |
+
+**Choices for `--format`:**
+
+- `csv`
+- `json`
+- `table`
+- `tsv`
+
+### `wbox contacts list`
+
+List contacts with optional filters.
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--active` / `--inactive` | `BOOLEAN` | `-` | Filter by active status |
+| `--assigned-to` | `INTEGER` | `-` | Filter by assigned user ID (client-side scan — fetches all pages). |
+| `--contact-type` | `TEXT` | `-` | Client, Prospect, Vendor, etc. - see wbox contacts categories contact-types |
+| `--deleted` | `BOOLEAN` | `-` | Filter to deleted contacts only (omit to see non-deleted, which is the API default) |
+| `--deleted-since` | `TEXT` | `-` | Only returns deleted contacts that were deleted on or after this timestamp |
+| `--email` | `TEXT` | `-` | Filter by email - Full Match |
+| `--format` | `CHOICE` | `json` |  |
+| `--household-title` | `CHOICE` | `-` | The household title you wish to filter the household title |
+| `--name` | `TEXT` | `-` | Filter by name - Contains |
+| `--order` | `CHOICE` | `asc` | The order that the contacts should be returned in |
+| `--page` | `INTEGER` | `-` | Page number |
+| `--per-page` | `INTEGER` | `-` | Results per page (max 100) |
+| `--phone` | `TEXT` | `-` | Filter by phone - Full Match - Parsing handled by Wealthbox |
+| `--tags` | `TEXT` | `-` | Comma-separated tags |
+| `--type` | `CHOICE` | `-` | Record Type - Person, Household, Organization, or Trust |
+| `--updated-before` | `TEXT` | `-` | Format of 'YYYY-MM-DD 07:00 AM -0700' |
+| `--updated-since` | `TEXT` | `-` | Format of 'YYYY-MM-DD 07:00 AM -0700' |
+| `--verbose` / `-v` | `BOOLEAN` | `false` | Show all fields |
+
+**Choices for `--format`:**
+
+- `csv`
+- `json`
+- `table`
+- `tsv`
+
+**Choices for `--household-title`:**
+
+- `Child`
+- `Grandchild`
+- `Grandparent`
+- `Head`
+- `Other Dependent`
+- `Parent`
+- `Partner`
+- `Sibling`
+- `Spouse`
+
+**Choices for `--order`:**
+
+- `asc`
+- `created`
+- `desc`
+- `recent`
+- `updated`
+
+**Choices for `--type`:**
+
+- `Household`
+- `Organization`
+- `Person`
+- `Trust`
+
+### `wbox contacts update`
+
+Update an existing contact. Pass only the fields you want to change.
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--active` / `--inactive` | `BOOLEAN` | `-` | Set contact status to Active or Inactive |
+| `--assigned-to` | `INTEGER` | `-` | Reassign to a user by ID |
+| `--company-name` | `TEXT` | `-` |  |
+| `--contact-source` | `TEXT` | `-` |  |
+| `--contact-type` | `TEXT` | `-` | e.g. Client, Prospect |
+| `--first-name` | `TEXT` | `-` |  |
+| `--format` | `CHOICE` | `json` |  |
+| `--job-title` | `TEXT` | `-` |  |
+| `--json` | `TEXT` | `-` | Full update as JSON (for nested fields like email_addresses) |
+| `--last-name` | `TEXT` | `-` |  |
+| `--middle-name` | `TEXT` | `-` |  |
+| `--name` | `TEXT` | `-` | Full name (for Household/Org/Trust) |
+| `--tags` | `TEXT` | `-` | Comma-separated tag names (e.g. 'VIP,Q1-Outreach'). Replaces all tags on the contact — include existing tags you wish to keep. New tags are auto-created. |
+
+**Choices for `--format`:**
+
+- `csv`
+- `json`
+- `table`
+- `tsv`
+<!-- /auto-gen:flags -->
+
 ## Examples
 
 ```bash

--- a/tests/test_skill_ref_gen.py
+++ b/tests/test_skill_ref_gen.py
@@ -1,0 +1,245 @@
+"""Tests for the skill-reference markdown auto-generator.
+
+The generator at :mod:`wealthbox_tools.internals.skill_ref_gen` rewrites
+the content between ``<!-- auto-gen:flags -->`` markers in skill reference
+markdown files. Slice #30 covers the ``contacts`` resource only; later
+slices roll markers across the rest of references/.
+
+These tests run the generator against an isolated copy of the references
+tree so they neither depend on nor mutate the real markdown files.
+"""
+from __future__ import annotations
+
+import shutil
+import sys
+from pathlib import Path
+
+import pytest
+
+from wealthbox_tools.internals import skill_ref_gen
+from wealthbox_tools.internals.skill_ref_gen import (
+    CLOSE_MARKER,
+    OPEN_MARKER,
+    regenerate_all,
+)
+
+# The single file in scope for slice #30. Other reference files are
+# handled in subsequent issues (#35).
+_RESOURCE = "contacts"
+_FILENAME = "contacts.md"
+
+
+def _real_references_dir() -> Path:
+    """Return the in-tree references directory the generator targets by default."""
+    return (
+        Path(skill_ref_gen.__file__).resolve().parent.parent
+        / "skills"
+        / "wealthbox-crm"
+        / "references"
+    )
+
+
+@pytest.fixture
+def refs_dir(tmp_path: Path) -> Path:
+    """Copy the real references dir to a tmp dir for isolated mutation."""
+    src = _real_references_dir()
+    dst = tmp_path / "references"
+    shutil.copytree(src, dst)
+    return dst
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _write(path: Path, text: str) -> None:
+    path.write_text(text, encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# 1. Idempotence
+# ---------------------------------------------------------------------------
+
+def test_idempotent_against_freshly_regenerated_tree(refs_dir: Path) -> None:
+    """Two consecutive regens of an isolated tree must produce zero changes
+    on the second pass."""
+    first = regenerate_all(references_dir=refs_dir)
+    # The first pass should populate the markers (initial commit ships with
+    # empty markers); after that, a re-run is a no-op.
+    second = regenerate_all(references_dir=refs_dir)
+    assert second.modified == [], (
+        f"second regen unexpectedly modified files: {second.modified}\n"
+        f"first pass modified: {first.modified}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. Drift detection
+# ---------------------------------------------------------------------------
+
+def test_drift_detection_restores_real_flags(refs_dir: Path) -> None:
+    """If a hand-edit injects a fake flag inside the markers, the next
+    regen removes the fake and restores the real flags."""
+    target = refs_dir / _FILENAME
+    # Bring the file into a freshly-generated state first.
+    regenerate_all(references_dir=refs_dir)
+    baseline = _read(target)
+
+    # Introduce drift: insert a fake flag row inside the auto-gen block.
+    fake = "FAKE-FLAG-SHOULD-BE-REMOVED"
+    drifted = baseline.replace(
+        OPEN_MARKER,
+        OPEN_MARKER + f"\n| `--{fake}` | TEXT | - | bogus |",
+        1,
+    )
+    assert fake in drifted
+    _write(target, drifted)
+
+    result = regenerate_all(references_dir=refs_dir)
+    assert target in result.modified
+    after = _read(target)
+    assert fake not in after
+    # And the real flags from the contacts list command should appear.
+    assert "--first-name" in after
+    assert "--contact-type" in after
+
+
+# ---------------------------------------------------------------------------
+# 3. Editorial preservation
+# ---------------------------------------------------------------------------
+
+def test_editorial_content_outside_markers_is_preserved(refs_dir: Path) -> None:
+    """Hand-edits outside the auto-gen markers must not be touched by
+    subsequent regens, even when the generated block is rewritten."""
+    target = refs_dir / _FILENAME
+    # Regenerate once to settle the auto-gen block.
+    regenerate_all(references_dir=refs_dir)
+
+    # Add a Tips section after the closing marker.
+    tip = "## Tips\n\nDon't forget to bring a towel.\n"
+    content = _read(target)
+    edited = content.replace(CLOSE_MARKER, CLOSE_MARKER + "\n\n" + tip, 1)
+    _write(target, edited)
+
+    # Force a regen by introducing drift inside the markers — this proves
+    # that even when the generator rewrites the block, the editorial
+    # section is left intact.
+    drifted = edited.replace(
+        OPEN_MARKER,
+        OPEN_MARKER + "\n<!-- forcibly-drifted -->",
+        1,
+    )
+    _write(target, drifted)
+
+    regenerate_all(references_dir=refs_dir)
+    after = _read(target)
+    assert tip.strip() in after
+    assert "forcibly-drifted" not in after
+
+
+# ---------------------------------------------------------------------------
+# 4. Missing markers
+# ---------------------------------------------------------------------------
+
+def test_missing_markers_skips_file_with_warning(
+    refs_dir: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A markdown file with no auto-gen markers is left unchanged and a
+    warning is emitted to stderr."""
+    target = refs_dir / _FILENAME
+    no_markers = "# Contacts\n\nNo markers here. Hand-written only.\n"
+    _write(target, no_markers)
+
+    result = regenerate_all(references_dir=refs_dir)
+    captured = capsys.readouterr()
+
+    assert _read(target) == no_markers
+    assert target in result.skipped_no_markers
+    assert target not in result.modified
+    assert "auto-gen markers not found" in captured.err
+    assert str(target) in captured.err
+
+
+# ---------------------------------------------------------------------------
+# 5. Determinism
+# ---------------------------------------------------------------------------
+
+def test_byte_for_byte_deterministic(tmp_path: Path) -> None:
+    """Two independent regens against identical fresh inputs produce
+    byte-identical files."""
+    src = _real_references_dir()
+
+    a = tmp_path / "a"
+    b = tmp_path / "b"
+    shutil.copytree(src, a)
+    shutil.copytree(src, b)
+
+    regenerate_all(references_dir=a)
+    regenerate_all(references_dir=b)
+
+    bytes_a = (a / _FILENAME).read_bytes()
+    bytes_b = (b / _FILENAME).read_bytes()
+    assert bytes_a == bytes_b
+
+
+# ---------------------------------------------------------------------------
+# 6. Enum rendering
+# ---------------------------------------------------------------------------
+
+def test_enum_field_renders_bulleted_choice_list(refs_dir: Path) -> None:
+    """A Pydantic/Typer enum-typed flag (e.g. `--type` on `contacts list`,
+    bound to ``RecordType``) must render as a bulleted list of valid values
+    in the generated block."""
+    target = refs_dir / _FILENAME
+    regenerate_all(references_dir=refs_dir)
+    content = _read(target)
+
+    # `wbox contacts list --type` is bound to RecordType — Person,
+    # Household, Organization, Trust.
+    # Find the generated block and assert structure.
+    assert OPEN_MARKER in content and CLOSE_MARKER in content
+    block = content.split(OPEN_MARKER, 1)[1].split(CLOSE_MARKER, 1)[0]
+    assert "**Choices for `--type`:**" in block
+    for value in ("Person", "Household", "Organization", "Trust"):
+        assert f"- `{value}`" in block
+
+
+# ---------------------------------------------------------------------------
+# Hidden-CLI smoke test (acceptance criterion: command is wired)
+# ---------------------------------------------------------------------------
+
+def test_internals_subapp_hidden_from_help() -> None:
+    """`internals` must not surface in `wbox --help` output."""
+    from typer.testing import CliRunner
+
+    from wealthbox_tools.cli.main import app
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0, result.stdout
+    assert "internals" not in result.stdout
+
+
+def test_internals_regen_skill_refs_runs(refs_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """`wbox internals regen-skill-refs` invokes the generator end-to-end."""
+    # Redirect the generator at our isolated tmp tree so the test never
+    # mutates the real in-tree markdown.
+    from typer.testing import CliRunner
+
+    from wealthbox_tools.cli.main import app
+
+    monkeypatch.setattr(
+        skill_ref_gen, "_references_dir", lambda: refs_dir
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["internals", "regen-skill-refs"])
+    assert result.exit_code == 0, result.stdout + "\n--stderr--\n" + (result.stderr or "")
+
+
+# ---------------------------------------------------------------------------
+# Self-check — guarantee the suite was actually pulled into pytest
+# ---------------------------------------------------------------------------
+
+def test_module_under_test_is_importable() -> None:
+    assert "wealthbox_tools.internals.skill_ref_gen" in sys.modules

--- a/tests/test_skill_ref_gen.py
+++ b/tests/test_skill_ref_gen.py
@@ -238,6 +238,39 @@ def test_internals_regen_skill_refs_runs(refs_dir: Path, monkeypatch: pytest.Mon
 
 
 # ---------------------------------------------------------------------------
+# Map-typo guard — a stale RESOURCE_REFERENCE_MAP entry must fail loudly,
+# not silently overwrite a reference file with an empty flag block.
+# ---------------------------------------------------------------------------
+
+def test_unknown_mapped_resource_raises(
+    refs_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If RESOURCE_REFERENCE_MAP names a resource that is not registered on the
+    root Typer app (typo, rename, or removed sub-app), regenerate_all must
+    raise rather than rewrite the target file with empty content."""
+    # Seed a markdown file with markers around real content so we can verify
+    # it is not mutated when the generator raises.
+    bogus_md = refs_dir / "no-such-resource.md"
+    bogus_md.write_text(
+        f"{OPEN_MARKER}\nplaceholder content that must survive\n{CLOSE_MARKER}\n",
+        encoding="utf-8",
+    )
+    before = bogus_md.read_text(encoding="utf-8")
+
+    monkeypatch.setattr(
+        skill_ref_gen,
+        "RESOURCE_REFERENCE_MAP",
+        {"no-such-resource": "no-such-resource.md"},
+    )
+
+    with pytest.raises(KeyError, match="no-such-resource"):
+        regenerate_all(references_dir=refs_dir)
+
+    # File untouched.
+    assert bogus_md.read_text(encoding="utf-8") == before
+
+
+# ---------------------------------------------------------------------------
 # Self-check — guarantee the suite was actually pulled into pytest
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Tracer-bullet implementation of the skill-ref auto-gen mechanism against `references/contacts.md`. Subsequent slices roll markers across remaining reference files (#35).
- New module `src/wealthbox_tools/internals/skill_ref_gen.py` exposes `regenerate_all() -> ChangeSet`. Walks the live Typer tree, rewrites only content between `<!-- auto-gen:flags -->` / `<!-- /auto-gen:flags -->` markers, leaves editorial content untouched. Deterministic byte-for-byte output.
- New hidden CLI command: `wbox internals regen-skill-refs` (registered with `hidden=True` on both the sub-app and command).

## Implementation notes

- The `cli.main` import is lazy (inside `_collect_commands_for_resource`) to break the import cycle: `cli.main` → `cli.internals` → `internals.skill_ref_gen`. Kept the package-level constants (`OPEN_MARKER`, `CLOSE_MARKER`, `RESOURCE_REFERENCE_MAP`) at module top.
- Determinism: commands and flags are sorted alphabetically; enum choice lists are sorted; whitespace and pipe-table formatting are fixed. A second regen of an unchanged tree is a no-op (verified locally).

## Conflict note

May conflict with #31 (PR #52) on `cli/main.py` sub-app registration — trivial to resolve at merge time.

## Test plan

- [x] `pytest tests/test_skill_ref_gen.py` — 9 tests pass (idempotence, drift, editorial preservation, missing markers, determinism, enum rendering, plus CLI smoke tests).
- [x] Full `pytest` — 281 passed.
- [x] `ruff check src/ tests/` — clean.
- [x] `wbox internals regen-skill-refs` then `git diff --exit-code -- references/contacts.md` — no diff after a fresh regen (idempotent).

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)