### PR TITLE
feat: wbox firm import overwrite mode (#36)

### DIFF
--- a/src/wealthbox_tools/cli/firm.py
+++ b/src/wealthbox_tools/cli/firm.py
@@ -5,7 +5,10 @@ from pathlib import Path
 
 import typer
 
+from ..firm import ApplyMode, ArchiveError
+from ..firm import apply as _apply
 from ..firm import pack as _pack
+from ..firm import unpack as _unpack
 from ._skill_paths import firm_dir as _firm_dir
 from .skills import _ensure_firm_migrated
 
@@ -42,3 +45,43 @@ def export_firm(
     out.parent.mkdir(parents=True, exist_ok=True)
     out.write_bytes(blob)
     typer.echo(f"Wrote {out} ({len(blob)} bytes).", err=True)
+
+
+@app.command("import")
+def import_firm(
+    path: Path = typer.Argument(
+        ...,
+        help="Path to a firm-archive zip produced by `wbox firm export`.",
+    ),
+    yes: bool = typer.Option(
+        False,
+        "--yes",
+        "-y",
+        help="Skip the overwrite confirmation prompt.",
+    ),
+) -> None:
+    """Import a firm-archive zip into the local firm directory (overwrite mode).
+
+    Overwrite is the default — every hand-edited policy file in the archive
+    replaces its counterpart in the firm directory. Files in the firm
+    directory that aren't in the archive (generated ``categories.md``,
+    ``custom-fields.md``, ``users.md``) are left untouched.
+    """
+    _ensure_firm_migrated()
+    try:
+        plan = _unpack(path)
+    except ArchiveError as exc:
+        raise typer.BadParameter(str(exc)) from exc
+
+    dest = _firm_dir()
+    if not yes:
+        typer.confirm(
+            f"Overwrite {len(plan.files)} file(s) in {dest}?",
+            abort=True,
+        )
+
+    try:
+        result = _apply(plan, dest, ApplyMode.OVERWRITE)
+    except ArchiveError as exc:
+        raise typer.BadParameter(str(exc)) from exc
+    typer.echo(f"Wrote {len(result.written)} file(s) to {dest}.", err=True)

--- a/src/wealthbox_tools/firm/__init__.py
+++ b/src/wealthbox_tools/firm/__init__.py
@@ -2,9 +2,30 @@
 
 Public surface:
 - ``pack(firm_dir)`` — zip a firm directory into a portable byte blob.
+- ``unpack(source)`` — read a firm-archive zip into an :class:`ImportPlan`.
+- ``apply(plan, firm_dir, mode)`` — write a plan onto a firm directory.
+- ``ApplyMode`` — overwrite / merge / abort-on-conflict (only overwrite is
+  implemented in the current slice).
+- ``ArchiveError`` — raised for malformed archives or unsupported modes.
 """
 from __future__ import annotations
 
-from .archive import pack
+from .archive import (
+    ApplyMode,
+    ApplyResult,
+    ArchiveError,
+    ImportPlan,
+    apply,
+    pack,
+    unpack,
+)
 
-__all__ = ["pack"]
+__all__ = [
+    "ApplyMode",
+    "ApplyResult",
+    "ArchiveError",
+    "ImportPlan",
+    "apply",
+    "pack",
+    "unpack",
+]

--- a/src/wealthbox_tools/firm/archive.py
+++ b/src/wealthbox_tools/firm/archive.py
@@ -212,6 +212,21 @@ def unpack(source: Path | str) -> ImportPlan:
                         "only hand-edited policy files and _meta.json are accepted."
                     )
             files = {name: zf.read(name) for name in entry_names}
+            # _meta.json must be a JSON object if present — otherwise the
+            # apply-side merge would have to fall back to writing raw
+            # bytes, bypassing META_POLICY_KEYS filtering and corrupting
+            # the destination's identity/cli_version/files cache.
+            if META_FILENAME in files:
+                try:
+                    meta_obj = json.loads(files[META_FILENAME].decode("utf-8"))
+                except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+                    raise ArchiveError(
+                        f"{path}: {META_FILENAME} is not valid JSON."
+                    ) from exc
+                if not isinstance(meta_obj, dict):
+                    raise ArchiveError(
+                        f"{path}: {META_FILENAME} must be a JSON object."
+                    )
     except zipfile.BadZipFile as exc:
         raise ArchiveError(f"{path}: not a valid zip archive.") from exc
     except FileNotFoundError as exc:
@@ -279,34 +294,28 @@ def apply(
 def _merge_meta_bytes(target: Path, incoming: bytes) -> bytes:
     """Merge the archive's ``_meta.json`` policy subset into the existing one.
 
-    ``pack`` only stores policy-shaped keys in ``_meta.json``. Wholesale
-    overwrite would delete generated keys (``identity``, ``cli_version``,
-    ``files``) that survive on the destination side. We merge the incoming
-    keys on top of the existing document so policy values come from the
-    archive while generated values persist locally. If either document is
-    missing or malformed, we fall back to writing the incoming bytes
-    verbatim — the same behavior as before the merge was introduced.
+    ``unpack`` already validated that ``incoming`` is a JSON object, so we
+    skip the malformed-incoming branch. Filter to META_POLICY_KEYS — the
+    same key whitelist ``pack`` enforces — so a tampered archive whose
+    ``_meta.json`` includes ``identity`` / ``cli_version`` / ``files``
+    cannot overwrite the destination's generated metadata. Generated keys
+    on the destination always survive; only policy keys come from the
+    archive.
+
+    If the destination ``_meta.json`` is missing or itself malformed, the
+    filtered policy subset is what gets written.
     """
-    try:
-        incoming_obj = json.loads(incoming.decode("utf-8"))
-    except (json.JSONDecodeError, UnicodeDecodeError):
-        return incoming
-    if not isinstance(incoming_obj, dict):
-        return incoming
-    # Filter to the same key whitelist that ``pack`` enforces — otherwise a
-    # tampered archive whose ``_meta.json`` includes ``identity`` /
-    # ``cli_version`` / ``files`` would let those forged values overwrite
-    # the destination's generated metadata. The file-level whitelist alone
-    # isn't sufficient for ``_meta.json``; we also need the key-level one.
-    incoming_policy = {k: incoming_obj[k] for k in META_POLICY_KEYS if k in incoming_obj}
-    if not target.exists():
-        return (json.dumps(incoming_policy, indent=2) + "\n").encode("utf-8")
-    try:
-        existing_obj = json.loads(target.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError):
-        return (json.dumps(incoming_policy, indent=2) + "\n").encode("utf-8")
-    if not isinstance(existing_obj, dict):
-        return (json.dumps(incoming_policy, indent=2) + "\n").encode("utf-8")
+    incoming_policy = {
+        k: v for k, v in json.loads(incoming).items() if k in META_POLICY_KEYS
+    }
+    existing_obj: dict[str, Any] = {}
+    if target.exists():
+        try:
+            loaded = json.loads(target.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            loaded = None
+        if isinstance(loaded, dict):
+            existing_obj = loaded
     merged = {**existing_obj, **incoming_policy}
     return (json.dumps(merged, indent=2) + "\n").encode("utf-8")
 

--- a/src/wealthbox_tools/firm/archive.py
+++ b/src/wealthbox_tools/firm/archive.py
@@ -132,10 +132,15 @@ class ApplyMode(StrEnum):
 def _is_safe_archive_name(name: str) -> bool:
     """Return ``True`` if ``name`` is safe to write under a target directory.
 
-    Rejects path-traversal (``..``), absolute paths, Windows drive letters,
-    and backslashes. The zip spec uses forward slashes, but malicious
-    archives may use backslashes specifically to bypass naive POSIX checks
-    on Windows — so we reject either form.
+    Rejects path-traversal (``..``), current-dir aliases (``.``), absolute
+    paths, Windows drive letters, backslashes, directory entries (trailing
+    slash), and empty path components. Anything that survives this check
+    can be safely joined onto ``firm_dir`` and written as a regular file.
+
+    ``.`` matters specifically because ``firm_dir / "."`` resolves to
+    ``firm_dir`` itself; ``write_bytes`` on a directory raises
+    ``IsADirectoryError``, which would bypass the CLI's clean-error path.
+    Trailing-slash directory entries have the same failure mode.
     """
     if not name:
         return False
@@ -143,10 +148,12 @@ def _is_safe_archive_name(name: str) -> bool:
         return False
     if name.startswith("/"):
         return False
+    if name.endswith("/"):
+        return False
     if len(name) >= 2 and name[1] == ":":
         return False
     parts = name.split("/")
-    if any(p == ".." for p in parts):
+    if any(p in ("", ".", "..") for p in parts):
         return False
     return True
 

--- a/src/wealthbox_tools/firm/archive.py
+++ b/src/wealthbox_tools/firm/archive.py
@@ -199,11 +199,17 @@ def unpack(source: Path | str) -> ImportPlan:
                     f"{path}: archive is missing {MANIFEST_NAME}; not a firm archive."
                 ) from exc
             entry_names = [n for n in zf.namelist() if n != MANIFEST_NAME]
+            allowed = set(HAND_EDITED_FILES) | {META_FILENAME}
             for entry in entry_names:
                 if not _is_safe_archive_name(entry):
                     raise ArchiveError(
                         f"{path}: archive contains unsafe entry path {entry!r}; "
                         "refusing to import."
+                    )
+                if entry not in allowed:
+                    raise ArchiveError(
+                        f"{path}: archive contains non-policy entry {entry!r}; "
+                        "only hand-edited policy files and _meta.json are accepted."
                     )
             files = {name: zf.read(name) for name in entry_names}
     except zipfile.BadZipFile as exc:

--- a/src/wealthbox_tools/firm/archive.py
+++ b/src/wealthbox_tools/firm/archive.py
@@ -104,6 +104,13 @@ def _build_manifest(
 #: Manifest filename inside the archive.
 MANIFEST_NAME = ".manifest.json"
 
+#: Filename of the per-firm metadata document. ``pack`` only includes the
+#: policy subset of this file (currently just ``onboarded_at``); ``apply``
+#: therefore merges that subset into the destination's existing meta rather
+#: than overwriting it, so generated keys (``identity``, ``cli_version``,
+#: ``files`` timestamps) that ``wbox doctor`` relies on survive.
+META_FILENAME = "_meta.json"
+
 
 class ArchiveError(Exception):
     """Raised when an archive cannot be unpacked or applied."""
@@ -249,9 +256,38 @@ def apply(
             )
         target = firm_dir / name
         target.parent.mkdir(parents=True, exist_ok=True)
+        if name == META_FILENAME:
+            content = _merge_meta_bytes(target, content)
         target.write_bytes(content)
         written.append(name)
     return ApplyResult(written=tuple(written))
+
+
+def _merge_meta_bytes(target: Path, incoming: bytes) -> bytes:
+    """Merge the archive's ``_meta.json`` policy subset into the existing one.
+
+    ``pack`` only stores policy-shaped keys in ``_meta.json``. Wholesale
+    overwrite would delete generated keys (``identity``, ``cli_version``,
+    ``files``) that survive on the destination side. We merge the incoming
+    keys on top of the existing document so policy values come from the
+    archive while generated values persist locally. If either document is
+    missing or malformed, we fall back to writing the incoming bytes
+    verbatim — the same behavior as before the merge was introduced.
+    """
+    try:
+        incoming_obj = json.loads(incoming.decode("utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return incoming
+    if not isinstance(incoming_obj, dict) or not target.exists():
+        return incoming
+    try:
+        existing_obj = json.loads(target.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return incoming
+    if not isinstance(existing_obj, dict):
+        return incoming
+    merged = {**existing_obj, **incoming_obj}
+    return (json.dumps(merged, indent=2) + "\n").encode("utf-8")
 
 
 def pack(firm_dir: Path, *, now: datetime | None = None) -> bytes:

--- a/src/wealthbox_tools/firm/archive.py
+++ b/src/wealthbox_tools/firm/archive.py
@@ -1,22 +1,30 @@
-"""Firm-archive packing.
+"""Firm-archive packing and unpacking.
 
 Produces a portable zip of a firm directory's hand-edited policy files plus
-a small manifest. The contract is **whitelist-only**: ``pack`` copies only
-the explicitly listed files into the archive — anything else in the source
-``firm_dir`` is silently dropped. This makes it impossible for generated
-files (``categories.md``, ``custom-fields.md``, ``users.md``), API-derived
+a small manifest, and applies such an archive back onto a firm directory.
+The pack contract is **whitelist-only**: ``pack`` copies only the explicitly
+listed files into the archive — anything else in the source ``firm_dir`` is
+silently dropped. This makes it impossible for generated files
+(``categories.md``, ``custom-fields.md``, ``users.md``), API-derived
 ``_meta.json`` fields (refresh timestamps, ``cli_version``), or ad-hoc
 debris in the firm directory to leak into the export.
 
 The user preferences directory (``~/.config/wbox/user/``) is never reachable
 from this module by construction: ``pack`` only sees ``firm_dir``.
+
+Apply modes (overwrite, merge, abort-on-conflict) are exposed as
+:class:`ApplyMode`, but only ``OVERWRITE`` is implemented in the current
+slice — ``MERGE`` and ``ABORT_ON_CONFLICT`` exist as enum values so future
+slices (#46) can wire their behavior in without breaking the public surface.
 """
 from __future__ import annotations
 
 import io
 import json
 import zipfile
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
+from enum import StrEnum
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _pkg_version
 from pathlib import Path
@@ -93,6 +101,126 @@ def _build_manifest(
     }
 
 
+#: Manifest filename inside the archive.
+MANIFEST_NAME = ".manifest.json"
+
+
+class ArchiveError(Exception):
+    """Raised when an archive cannot be unpacked or applied."""
+
+
+class ApplyMode(StrEnum):
+    """How :func:`apply` reconciles archive contents with the firm directory.
+
+    Only ``OVERWRITE`` is implemented in the current slice (#36). ``MERGE``
+    and ``ABORT_ON_CONFLICT`` are placeholders that #46 will wire up against
+    the same :func:`apply` surface.
+    """
+
+    OVERWRITE = "overwrite"
+    MERGE = "merge"
+    ABORT_ON_CONFLICT = "abort-on-conflict"
+
+
+@dataclass(frozen=True)
+class ImportPlan:
+    """The contents of a successfully-unpacked archive, ready to apply.
+
+    ``manifest`` is the parsed ``.manifest.json``. ``files`` maps each
+    archive entry's relative path to its raw bytes — keeping bytes (not
+    str) means future binary entries pass through unchanged.
+    """
+
+    manifest: dict[str, Any]
+    files: dict[str, bytes] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ApplyResult:
+    """Outcome of an :func:`apply` invocation."""
+
+    written: tuple[str, ...]
+
+
+def unpack(source: Path | str) -> ImportPlan:
+    """Read a firm-archive zip from disk and return its :class:`ImportPlan`.
+
+    URL fetch is deferred to issue #45; ``source`` is treated as a local
+    filesystem path for now.
+
+    Raises:
+        ArchiveError: the file isn't a valid zip, the manifest is missing
+            or malformed, or the manifest's ``format_version`` is newer
+            than this CLI understands.
+    """
+    path = Path(source)
+    try:
+        with zipfile.ZipFile(path, mode="r") as zf:
+            try:
+                manifest_raw = zf.read(MANIFEST_NAME)
+            except KeyError as exc:
+                raise ArchiveError(
+                    f"{path}: archive is missing {MANIFEST_NAME}; not a firm archive."
+                ) from exc
+            files = {
+                name: zf.read(name)
+                for name in zf.namelist()
+                if name != MANIFEST_NAME
+            }
+    except zipfile.BadZipFile as exc:
+        raise ArchiveError(f"{path}: not a valid zip archive.") from exc
+
+    try:
+        manifest = json.loads(manifest_raw.decode("utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise ArchiveError(f"{path}: {MANIFEST_NAME} is not valid JSON.") from exc
+    if not isinstance(manifest, dict):
+        raise ArchiveError(f"{path}: {MANIFEST_NAME} must be a JSON object.")
+
+    version = manifest.get("format_version")
+    if not isinstance(version, int) or version > FORMAT_VERSION:
+        raise ArchiveError(
+            f"{path}: unsupported format_version {version!r}. "
+            f"This CLI understands format_version up to {FORMAT_VERSION}; "
+            "upgrade `wealthbox-cli` to read this archive."
+        )
+
+    return ImportPlan(manifest=manifest, files=files)
+
+
+def apply(
+    plan: ImportPlan,
+    firm_dir: Path,
+    mode: ApplyMode = ApplyMode.OVERWRITE,
+) -> ApplyResult:
+    """Write the files from ``plan`` into ``firm_dir`` according to ``mode``.
+
+    In ``OVERWRITE`` mode every file in the plan is written unconditionally;
+    files already in ``firm_dir`` that are not in the plan are left alone
+    (the archive is whitelist-only, so generated files like
+    ``categories.md`` survive untouched on the destination).
+
+    ``MERGE`` and ``ABORT_ON_CONFLICT`` are not implemented in this slice
+    and raise :class:`ArchiveError`. Issue #46 will fill them in.
+    """
+    if mode is not ApplyMode.OVERWRITE:
+        raise ArchiveError(
+            f"apply mode {mode.value!r} is not implemented yet; only "
+            f"{ApplyMode.OVERWRITE.value!r} is supported in this release."
+        )
+
+    firm_dir = Path(firm_dir)
+    firm_dir.mkdir(parents=True, exist_ok=True)
+
+    written: list[str] = []
+    for name, content in plan.files.items():
+        target = firm_dir / name
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(content)
+        written.append(name)
+    return ApplyResult(written=tuple(written))
+
+
 def pack(firm_dir: Path, *, now: datetime | None = None) -> bytes:
     """Pack a firm directory into a zip blob.
 
@@ -122,7 +250,7 @@ def pack(firm_dir: Path, *, now: datetime | None = None) -> bytes:
 
     buf = io.BytesIO()
     with zipfile.ZipFile(buf, mode="w", compression=zipfile.ZIP_DEFLATED) as zf:
-        zf.writestr(".manifest.json", json.dumps(manifest, indent=2) + "\n")
+        zf.writestr(MANIFEST_NAME, json.dumps(manifest, indent=2) + "\n")
         if meta_policy:
             zf.writestr("_meta.json", json.dumps(meta_policy, indent=2) + "\n")
         for name in HAND_EDITED_FILES:

--- a/src/wealthbox_tools/firm/archive.py
+++ b/src/wealthbox_tools/firm/archive.py
@@ -122,6 +122,28 @@ class ApplyMode(StrEnum):
     ABORT_ON_CONFLICT = "abort-on-conflict"
 
 
+def _is_safe_archive_name(name: str) -> bool:
+    """Return ``True`` if ``name`` is safe to write under a target directory.
+
+    Rejects path-traversal (``..``), absolute paths, Windows drive letters,
+    and backslashes. The zip spec uses forward slashes, but malicious
+    archives may use backslashes specifically to bypass naive POSIX checks
+    on Windows — so we reject either form.
+    """
+    if not name:
+        return False
+    if "\\" in name:
+        return False
+    if name.startswith("/"):
+        return False
+    if len(name) >= 2 and name[1] == ":":
+        return False
+    parts = name.split("/")
+    if any(p == ".." for p in parts):
+        return False
+    return True
+
+
 @dataclass(frozen=True)
 class ImportPlan:
     """The contents of a successfully-unpacked archive, ready to apply.
@@ -162,13 +184,20 @@ def unpack(source: Path | str) -> ImportPlan:
                 raise ArchiveError(
                     f"{path}: archive is missing {MANIFEST_NAME}; not a firm archive."
                 ) from exc
-            files = {
-                name: zf.read(name)
-                for name in zf.namelist()
-                if name != MANIFEST_NAME
-            }
+            entry_names = [n for n in zf.namelist() if n != MANIFEST_NAME]
+            for entry in entry_names:
+                if not _is_safe_archive_name(entry):
+                    raise ArchiveError(
+                        f"{path}: archive contains unsafe entry path {entry!r}; "
+                        "refusing to import."
+                    )
+            files = {name: zf.read(name) for name in entry_names}
     except zipfile.BadZipFile as exc:
         raise ArchiveError(f"{path}: not a valid zip archive.") from exc
+    except FileNotFoundError as exc:
+        raise ArchiveError(f"{path}: archive file not found.") from exc
+    except OSError as exc:
+        raise ArchiveError(f"{path}: cannot read archive: {exc}") from exc
 
     try:
         manifest = json.loads(manifest_raw.decode("utf-8"))
@@ -214,6 +243,10 @@ def apply(
 
     written: list[str] = []
     for name, content in plan.files.items():
+        if not _is_safe_archive_name(name):
+            raise ArchiveError(
+                f"plan contains unsafe entry path {name!r}; refusing to write."
+            )
         target = firm_dir / name
         target.parent.mkdir(parents=True, exist_ok=True)
         target.write_bytes(content)

--- a/src/wealthbox_tools/firm/archive.py
+++ b/src/wealthbox_tools/firm/archive.py
@@ -291,15 +291,23 @@ def _merge_meta_bytes(target: Path, incoming: bytes) -> bytes:
         incoming_obj = json.loads(incoming.decode("utf-8"))
     except (json.JSONDecodeError, UnicodeDecodeError):
         return incoming
-    if not isinstance(incoming_obj, dict) or not target.exists():
+    if not isinstance(incoming_obj, dict):
         return incoming
+    # Filter to the same key whitelist that ``pack`` enforces — otherwise a
+    # tampered archive whose ``_meta.json`` includes ``identity`` /
+    # ``cli_version`` / ``files`` would let those forged values overwrite
+    # the destination's generated metadata. The file-level whitelist alone
+    # isn't sufficient for ``_meta.json``; we also need the key-level one.
+    incoming_policy = {k: incoming_obj[k] for k in META_POLICY_KEYS if k in incoming_obj}
+    if not target.exists():
+        return (json.dumps(incoming_policy, indent=2) + "\n").encode("utf-8")
     try:
         existing_obj = json.loads(target.read_text(encoding="utf-8"))
     except (json.JSONDecodeError, OSError):
-        return incoming
+        return (json.dumps(incoming_policy, indent=2) + "\n").encode("utf-8")
     if not isinstance(existing_obj, dict):
-        return incoming
-    merged = {**existing_obj, **incoming_obj}
+        return (json.dumps(incoming_policy, indent=2) + "\n").encode("utf-8")
+    merged = {**existing_obj, **incoming_policy}
     return (json.dumps(merged, indent=2) + "\n").encode("utf-8")
 
 

--- a/tests/test_firm_import.py
+++ b/tests/test_firm_import.py
@@ -173,6 +173,84 @@ def test_unpack_rejects_unknown_format_version(tmp_path: Path) -> None:
     assert "99" in msg
 
 
+def test_unpack_wraps_missing_file_as_archive_error(tmp_path: Path) -> None:
+    """A non-existent path raises ArchiveError, not FileNotFoundError, so the
+    CLI's ``except ArchiveError`` branch is reached and the user sees a clean
+    BadParameter rather than a stack trace."""
+    missing = tmp_path / "does_not_exist.zip"
+    with pytest.raises(ArchiveError) as excinfo:
+        unpack(missing)
+    assert "does_not_exist.zip" in str(excinfo.value)
+
+
+@pytest.mark.parametrize(
+    "evil_name",
+    [
+        "../escape.md",                # parent traversal
+        "subdir/../../escape.md",      # nested traversal
+        "/abs/path.md",                # posix absolute
+        "C:/Windows/system.md",        # windows drive letter
+        "..\\escape.md",               # backslash traversal (zip spec is /, but
+                                       # malicious archives may use \\ to bypass
+                                       # naive checks on Windows)
+    ],
+)
+def test_unpack_rejects_unsafe_archive_entry_paths(
+    tmp_path: Path, evil_name: str
+) -> None:
+    """Path-traversal and absolute entries must not survive unpack.
+
+    Without this guard, ``apply`` would write outside ``firm_dir`` — once #45
+    lets URLs be the source, an attacker-crafted archive could overwrite any
+    file the user can write."""
+    archive = _zip_with_manifest(
+        tmp_path / "evil.zip",
+        manifest={
+            "format_version": 1,
+            "exported_at": "2026-01-01T00:00:00+00:00",
+            "source_firm_name": None,
+            "source_cli_version": "1.0.0",
+        },
+        bodies={evil_name: "# pwned\n"},
+    )
+    with pytest.raises(ArchiveError) as excinfo:
+        unpack(archive)
+    assert "unsafe" in str(excinfo.value).lower() or "path" in str(excinfo.value).lower()
+
+
+def test_apply_rejects_unsafe_paths_in_hand_built_plan(tmp_path: Path) -> None:
+    """Defense in depth: ImportPlan is a public dataclass, so apply also guards.
+
+    If a caller constructs a plan whose ``files`` dict contains an unsafe
+    name (bypassing ``unpack``), ``apply`` must refuse to write outside
+    ``firm_dir`` rather than trust the plan blindly.
+    """
+    from wealthbox_tools.firm.archive import ImportPlan
+
+    dst = tmp_path / "firm"
+    dst.mkdir()
+    plan = ImportPlan(
+        manifest={"format_version": 1},
+        files={"../escape.md": b"# pwned\n"},
+    )
+    with pytest.raises(ArchiveError):
+        apply(plan, dst, ApplyMode.OVERWRITE)
+    assert not (tmp_path / "escape.md").exists()
+
+
+def test_firm_import_cli_surfaces_clear_error_on_missing_file(
+    runner, tmp_path: Path
+) -> None:
+    """A missing archive path must exit cleanly via BadParameter, not crash."""
+    missing = tmp_path / "nope.zip"
+
+    result = runner.invoke(app, ["firm", "import", str(missing), "--yes"])
+
+    assert result.exit_code != 0
+    combined = (result.stdout or "") + (result.stderr or "")
+    assert "Traceback" not in combined
+
+
 def test_apply_mode_enum_has_three_values() -> None:
     """The enum carries the three modes named in the brief, even though only
     overwrite is implemented in this slice — sibling issues #46/#47 wire the

--- a/tests/test_firm_import.py
+++ b/tests/test_firm_import.py
@@ -261,6 +261,39 @@ def test_unpack_rejects_unsafe_archive_entry_paths(
     assert "unsafe" in str(excinfo.value).lower() or "path" in str(excinfo.value).lower()
 
 
+@pytest.mark.parametrize(
+    "stray_name",
+    [
+        "categories.md",        # generated; would poison the local cache
+        "custom-fields.md",     # generated
+        "users.md",             # generated
+        "subdir/policy.md",     # nested anything
+        "firm.zip",             # arbitrary
+    ],
+)
+def test_unpack_rejects_non_policy_entries(tmp_path: Path, stray_name: str) -> None:
+    """``pack`` is whitelist-only (HAND_EDITED_FILES + _meta.json); ``unpack``
+    must enforce the same whitelist so a tampered archive can't smuggle
+    generated files (``categories.md``, ``users.md``) past apply and poison
+    caches that the skill bootstrap relies on."""
+    archive = _zip_with_manifest(
+        tmp_path / "tampered.zip",
+        manifest={
+            "format_version": 1,
+            "exported_at": "2026-01-01T00:00:00+00:00",
+            "source_firm_name": None,
+            "source_cli_version": "1.0.0",
+        },
+        bodies={
+            "contacts.md": "# Contacts policy\n",
+            stray_name: "# tampered payload\n",
+        },
+    )
+    with pytest.raises(ArchiveError) as excinfo:
+        unpack(archive)
+    assert stray_name in str(excinfo.value)
+
+
 def test_apply_rejects_unsafe_paths_in_hand_built_plan(tmp_path: Path) -> None:
     """Defense in depth: ImportPlan is a public dataclass, so apply also guards.
 

--- a/tests/test_firm_import.py
+++ b/tests/test_firm_import.py
@@ -163,6 +163,35 @@ def test_apply_overwrite_merges_meta_instead_of_replacing(tmp_path: Path) -> Non
     assert merged["files"] == {"categories.md": "2026-04-01T00:00:00+00:00"}
 
 
+@pytest.mark.parametrize(
+    "bad_meta_body",
+    [
+        "not json at all",                # JSONDecodeError
+        "[1, 2, 3]",                      # JSON array, not object
+        '"a string"',                     # JSON string, not object
+        "null",                           # JSON null
+    ],
+)
+def test_unpack_rejects_malformed_meta_json(tmp_path: Path, bad_meta_body: str) -> None:
+    """A tampered ``_meta.json`` with invalid JSON or a non-object payload
+    must be rejected at unpack time. The previous fallback wrote the raw
+    bytes verbatim, which bypassed META_POLICY_KEYS filtering and could
+    corrupt the destination's identity/cli_version/files cache."""
+    archive = _zip_with_manifest(
+        tmp_path / "evil.zip",
+        manifest={
+            "format_version": 1,
+            "exported_at": "2026-01-01T00:00:00+00:00",
+            "source_firm_name": None,
+            "source_cli_version": "1.0.0",
+        },
+        bodies={"_meta.json": bad_meta_body},
+    )
+    with pytest.raises(ArchiveError) as excinfo:
+        unpack(archive)
+    assert "_meta.json" in str(excinfo.value)
+
+
 def test_apply_filters_incoming_meta_to_policy_keys(tmp_path: Path) -> None:
     """A tampered ``_meta.json`` that includes generated keys (identity,
     cli_version, files) must NOT overwrite the destination's values for

--- a/tests/test_firm_import.py
+++ b/tests/test_firm_import.py
@@ -126,6 +126,43 @@ def test_apply_overwrite_replaces_existing_content(tmp_path: Path) -> None:
     assert (dst / "contacts.md").read_text(encoding="utf-8") == bodies["contacts.md"]
 
 
+def test_apply_overwrite_merges_meta_instead_of_replacing(tmp_path: Path) -> None:
+    """``_meta.json`` is the only archive entry that needs merge semantics.
+
+    ``pack`` deliberately strips ``_meta.json`` down to the policy subset
+    (just ``onboarded_at``). If ``apply`` wrote that subset wholesale, it
+    would destroy the destination's ``identity``, ``cli_version``, and
+    ``files`` timestamps that ``wbox doctor`` and the skill bootstrap
+    machinery depend on. Apply must merge the policy keys *into* the
+    existing meta, not replace it.
+    """
+    src = tmp_path / "src"
+    _populated_firm_dir(src)
+    archive = tmp_path / "firm.zip"
+    archive.write_bytes(pack(src, now=_PINNED_NOW))
+
+    dst = tmp_path / "dst"
+    dst.mkdir()
+    pre_existing = {
+        "identity": {"id": 42, "name": "Local Firm", "user_id": 7},
+        "cli_version": "1.6.0",
+        "files": {"categories.md": "2026-04-01T00:00:00+00:00"},
+        "onboarded_at": "2025-01-01T00:00:00+00:00",
+    }
+    (dst / "_meta.json").write_text(json.dumps(pre_existing, indent=2), encoding="utf-8")
+
+    plan = unpack(archive)
+    apply(plan, dst, ApplyMode.OVERWRITE)
+
+    merged = json.loads((dst / "_meta.json").read_text(encoding="utf-8"))
+    # Policy keys from the archive overwrite the destination's values.
+    assert merged["onboarded_at"] == "2024-02-15T12:34:56+00:00"
+    # Generated/identity keys survive.
+    assert merged["identity"] == {"id": 42, "name": "Local Firm", "user_id": 7}
+    assert merged["cli_version"] == "1.6.0"
+    assert merged["files"] == {"categories.md": "2026-04-01T00:00:00+00:00"}
+
+
 def test_apply_overwrite_leaves_unrelated_files_alone(tmp_path: Path) -> None:
     """Generated files that weren't in the archive must not be touched.
 

--- a/tests/test_firm_import.py
+++ b/tests/test_firm_import.py
@@ -163,6 +163,57 @@ def test_apply_overwrite_merges_meta_instead_of_replacing(tmp_path: Path) -> Non
     assert merged["files"] == {"categories.md": "2026-04-01T00:00:00+00:00"}
 
 
+def test_apply_filters_incoming_meta_to_policy_keys(tmp_path: Path) -> None:
+    """A tampered ``_meta.json`` that includes generated keys (identity,
+    cli_version, files) must NOT overwrite the destination's values for
+    those keys. ``pack`` only writes META_POLICY_KEYS into the archive's
+    meta, so ``apply`` must symmetrically only accept those keys —
+    otherwise the whitelist-symmetry from #36's fix only applies at
+    file-name granularity, not at the key-level granularity that pack
+    enforces inside ``_meta.json``.
+    """
+    # Hand-craft a tampered archive whose _meta.json contains a forged
+    # identity. The whitelist-only file check passes (it's _meta.json), so
+    # the protection has to live in the merge step.
+    tampered_meta = {
+        "onboarded_at": "2024-02-15T12:34:56+00:00",  # legit policy key
+        "identity": {"id": 999, "name": "Forged", "user_id": 999},
+        "cli_version": "9.9.9",
+        "files": {"categories.md": "1970-01-01T00:00:00+00:00"},
+    }
+    archive = _zip_with_manifest(
+        tmp_path / "tampered.zip",
+        manifest={
+            "format_version": 1,
+            "exported_at": "2026-01-01T00:00:00+00:00",
+            "source_firm_name": None,
+            "source_cli_version": "1.0.0",
+        },
+        bodies={"_meta.json": json.dumps(tampered_meta, indent=2)},
+    )
+
+    dst = tmp_path / "dst"
+    dst.mkdir()
+    legitimate = {
+        "identity": {"id": 42, "name": "Local Firm", "user_id": 7},
+        "cli_version": "1.6.0",
+        "files": {"categories.md": "2026-04-01T00:00:00+00:00"},
+        "onboarded_at": "2025-01-01T00:00:00+00:00",
+    }
+    (dst / "_meta.json").write_text(json.dumps(legitimate, indent=2), encoding="utf-8")
+
+    plan = unpack(archive)
+    apply(plan, dst, ApplyMode.OVERWRITE)
+
+    merged = json.loads((dst / "_meta.json").read_text(encoding="utf-8"))
+    # Policy key is taken from the archive.
+    assert merged["onboarded_at"] == "2024-02-15T12:34:56+00:00"
+    # Generated keys must NOT have been overwritten by the tampered archive.
+    assert merged["identity"] == legitimate["identity"]
+    assert merged["cli_version"] == legitimate["cli_version"]
+    assert merged["files"] == legitimate["files"]
+
+
 def test_apply_overwrite_leaves_unrelated_files_alone(tmp_path: Path) -> None:
     """Generated files that weren't in the archive must not be touched.
 

--- a/tests/test_firm_import.py
+++ b/tests/test_firm_import.py
@@ -1,0 +1,250 @@
+"""Tests for ``wbox firm import`` and the underlying ``firm.archive`` unpack/apply.
+
+Issue #36 — overwrite mode only. Sibling slices (#45 URL fetch, #46 merge /
+abort-on-conflict, #47 diff, #48 post-import metadata) are blocked by this
+one and will extend the same ``unpack`` / ``apply`` / ``ApplyMode`` surface.
+"""
+from __future__ import annotations
+
+import io
+import json
+import zipfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from wealthbox_tools.cli.main import app
+from wealthbox_tools.firm.archive import (
+    ApplyMode,
+    ArchiveError,
+    apply,
+    pack,
+    unpack,
+)
+
+# --------------------------------------------------------------------------- #
+# Helpers                                                                      #
+# --------------------------------------------------------------------------- #
+
+
+_PINNED_NOW = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+
+def _populated_firm_dir(root: Path) -> dict[str, str]:
+    """Create a firm dir matching the export-side fixture.
+
+    Returns the hand-edited bodies so tests can assert round-trip equality.
+    """
+    root.mkdir(parents=True, exist_ok=True)
+    bodies = {
+        "contacts.md": "# Contacts policy\n\nUse household-first onboarding.\n",
+        "tasks.md": "# Tasks policy\n\nDefault priority is medium.\n",
+        "notes.md": "# Notes policy\n",
+        "events.md": "# Events policy\n",
+        "opportunities.md": "# Opportunities policy\n",
+        "projects.md": "# Projects policy\n",
+        "workflows.md": "# Workflows policy\n",
+    }
+    for name, body in bodies.items():
+        (root / name).write_text(body, encoding="utf-8")
+    (root / "_meta.json").write_text(
+        json.dumps({"onboarded_at": "2024-02-15T12:34:56+00:00"}, indent=2),
+        encoding="utf-8",
+    )
+    return bodies
+
+
+def _zip_with_manifest(path: Path, manifest: dict, bodies: dict[str, str] | None = None) -> Path:
+    """Hand-craft a zip archive with the given manifest and optional file bodies."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, mode="w", compression=zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr(".manifest.json", json.dumps(manifest, indent=2) + "\n")
+        for name, body in (bodies or {}).items():
+            zf.writestr(name, body)
+    path.write_bytes(buf.getvalue())
+    return path
+
+
+# --------------------------------------------------------------------------- #
+# Round-trip: unpack + apply(overwrite)                                        #
+# --------------------------------------------------------------------------- #
+
+
+def test_round_trip_overwrite_writes_hand_edited_files(tmp_path: Path) -> None:
+    """Pack → unpack → apply(overwrite) reproduces the hand-edited tree."""
+    src = tmp_path / "src"
+    bodies = _populated_firm_dir(src)
+    blob = pack(src, now=_PINNED_NOW)
+    archive = tmp_path / "firm.zip"
+    archive.write_bytes(blob)
+
+    plan = unpack(archive)
+    dst = tmp_path / "dst"
+    dst.mkdir()
+
+    result = apply(plan, dst, ApplyMode.OVERWRITE)
+
+    for name, expected in bodies.items():
+        assert (dst / name).read_text(encoding="utf-8") == expected
+    # Round-trip also restores the policy-shaped _meta.json.
+    assert json.loads((dst / "_meta.json").read_text(encoding="utf-8")) == {
+        "onboarded_at": "2024-02-15T12:34:56+00:00",
+    }
+    # ApplyResult reports every file actually written.
+    assert set(result.written) == set(bodies) | {"_meta.json"}
+
+
+def test_unpack_exposes_manifest(tmp_path: Path) -> None:
+    """The plan carries the manifest so callers can introspect format_version etc."""
+    src = tmp_path / "src"
+    _populated_firm_dir(src)
+    archive = tmp_path / "firm.zip"
+    archive.write_bytes(pack(src, now=_PINNED_NOW))
+
+    plan = unpack(archive)
+
+    assert plan.manifest["format_version"] == 1
+    assert plan.manifest["exported_at"] == "2026-01-01T00:00:00+00:00"
+    assert plan.manifest["source_firm_name"] is None  # no identity in the fixture
+
+
+def test_apply_overwrite_replaces_existing_content(tmp_path: Path) -> None:
+    """Overwrite truly overwrites — pre-existing content is replaced, not merged."""
+    src = tmp_path / "src"
+    bodies = _populated_firm_dir(src)
+    archive = tmp_path / "firm.zip"
+    archive.write_bytes(pack(src, now=_PINNED_NOW))
+
+    dst = tmp_path / "dst"
+    dst.mkdir()
+    (dst / "contacts.md").write_text("# stale local edits\n", encoding="utf-8")
+
+    plan = unpack(archive)
+    apply(plan, dst, ApplyMode.OVERWRITE)
+
+    assert (dst / "contacts.md").read_text(encoding="utf-8") == bodies["contacts.md"]
+
+
+def test_apply_overwrite_leaves_unrelated_files_alone(tmp_path: Path) -> None:
+    """Generated files that weren't in the archive must not be touched.
+
+    The archive is whitelist-only, so categories.md / custom-fields.md / users.md
+    stay untouched on the destination side.
+    """
+    src = tmp_path / "src"
+    _populated_firm_dir(src)
+    archive = tmp_path / "firm.zip"
+    archive.write_bytes(pack(src, now=_PINNED_NOW))
+
+    dst = tmp_path / "dst"
+    dst.mkdir()
+    (dst / "categories.md").write_text("# locally regenerated\n", encoding="utf-8")
+
+    plan = unpack(archive)
+    apply(plan, dst, ApplyMode.OVERWRITE)
+
+    assert (dst / "categories.md").read_text(encoding="utf-8") == "# locally regenerated\n"
+
+
+# --------------------------------------------------------------------------- #
+# Manifest version validation                                                  #
+# --------------------------------------------------------------------------- #
+
+
+def test_unpack_rejects_unknown_format_version(tmp_path: Path) -> None:
+    """A zip with format_version > 1 raises ArchiveError with a clear message."""
+    archive = _zip_with_manifest(
+        tmp_path / "future.zip",
+        manifest={
+            "format_version": 99,
+            "exported_at": "2026-01-01T00:00:00+00:00",
+            "source_firm_name": None,
+            "source_cli_version": "9.9.9",
+        },
+        bodies={"contacts.md": "# from the future\n"},
+    )
+
+    with pytest.raises(ArchiveError) as excinfo:
+        unpack(archive)
+
+    msg = str(excinfo.value)
+    assert "format_version" in msg
+    assert "99" in msg
+
+
+def test_apply_mode_enum_has_three_values() -> None:
+    """The enum carries the three modes named in the brief, even though only
+    overwrite is implemented in this slice — sibling issues #46/#47 wire the
+    others up against the same surface."""
+    assert ApplyMode("overwrite") is ApplyMode.OVERWRITE
+    assert ApplyMode("merge") is ApplyMode.MERGE
+    assert ApplyMode("abort-on-conflict") is ApplyMode.ABORT_ON_CONFLICT
+
+
+# --------------------------------------------------------------------------- #
+# CLI: wbox firm import <path>                                                 #
+# --------------------------------------------------------------------------- #
+
+
+def test_firm_import_cli_yes_skips_prompt_and_writes(runner, tmp_path: Path) -> None:
+    """`wbox firm import <path> --yes` overwrites the local firm dir without prompting."""
+    from wealthbox_tools.cli._skill_paths import firm_dir
+
+    src = tmp_path / "src"
+    bodies = _populated_firm_dir(src)
+    archive = tmp_path / "firm.zip"
+    archive.write_bytes(pack(src, now=_PINNED_NOW))
+
+    fd = firm_dir()
+    fd.mkdir(parents=True, exist_ok=True)
+
+    result = runner.invoke(app, ["firm", "import", str(archive), "--yes"])
+
+    assert result.exit_code == 0, result.stdout
+    for name, expected in bodies.items():
+        assert (fd / name).read_text(encoding="utf-8") == expected
+
+
+def test_firm_import_cli_aborts_when_user_declines_prompt(
+    runner, tmp_path: Path
+) -> None:
+    """Without ``--yes``, declining the prompt leaves the firm dir untouched."""
+    from wealthbox_tools.cli._skill_paths import firm_dir
+
+    src = tmp_path / "src"
+    _populated_firm_dir(src)
+    archive = tmp_path / "firm.zip"
+    archive.write_bytes(pack(src, now=_PINNED_NOW))
+
+    fd = firm_dir()
+    fd.mkdir(parents=True, exist_ok=True)
+    pre_existing = "# DO NOT TOUCH\n"
+    (fd / "contacts.md").write_text(pre_existing, encoding="utf-8")
+
+    result = runner.invoke(app, ["firm", "import", str(archive)], input="n\n")
+
+    assert result.exit_code != 0
+    assert (fd / "contacts.md").read_text(encoding="utf-8") == pre_existing
+
+
+def test_firm_import_cli_surfaces_clear_error_on_bad_format_version(
+    runner, tmp_path: Path
+) -> None:
+    """ArchiveError must reach the user as a clean message, not a stack trace."""
+    archive = _zip_with_manifest(
+        tmp_path / "future.zip",
+        manifest={
+            "format_version": 99,
+            "exported_at": "2026-01-01T00:00:00+00:00",
+            "source_firm_name": None,
+            "source_cli_version": "9.9.9",
+        },
+    )
+
+    result = runner.invoke(app, ["firm", "import", str(archive), "--yes"])
+
+    assert result.exit_code != 0
+    combined = (result.stdout or "") + (result.stderr or "")
+    assert "format_version" in combined
+    assert "Traceback" not in combined

--- a/tests/test_firm_import.py
+++ b/tests/test_firm_import.py
@@ -230,6 +230,12 @@ def test_unpack_wraps_missing_file_as_archive_error(tmp_path: Path) -> None:
         "..\\escape.md",               # backslash traversal (zip spec is /, but
                                        # malicious archives may use \\ to bypass
                                        # naive checks on Windows)
+        ".",                           # current-dir; would resolve onto firm_dir
+        "./contacts.md",               # leading-dot segment
+        "contacts/./policy.md",        # mid-path-dot segment
+        "subdir/",                     # directory entry; write_bytes on a dir
+                                       # raises IsADirectoryError otherwise
+        "foo//bar.md",                 # empty middle segment
     ],
 )
 def test_unpack_rejects_unsafe_archive_entry_paths(


### PR DESCRIPTION
## Summary

- `firm.archive.unpack(Path) -> ImportPlan` reads a firm-archive zip and validates `format_version` (raises `ArchiveError` for anything > 1).
- `firm.archive.apply(plan, firm_dir, ApplyMode.OVERWRITE) -> ApplyResult` writes every file in the plan unconditionally; `MERGE` / `ABORT_ON_CONFLICT` are reserved enum values that raise `ArchiveError` until #46.
- `wbox firm import <path>` confirms overwrite by default (`--yes` skips), surfaces `ArchiveError` as a clean `typer.BadParameter`.

Sibling issues #45 (URL fetch), #46 (merge / abort-on-conflict), #47 (diff), and #48 (post-import metadata) all extend this surface without breaking it.

## Test plan
- [x] `pytest tests/test_firm_import.py` — 9 new tests cover round-trip, overwrite-replaces-existing, unrelated files left alone, manifest exposure, format_version rejection, enum sanity, and the three CLI paths (yes / declined prompt / bad-version error)
- [x] `pytest` — full suite, 299 passed
- [x] `ruff check src/ tests/` — clean
- [ ] Manual: `wbox firm export --out /tmp/firm.zip && wbox firm import /tmp/firm.zip --yes` round-trip

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)