### PR TITLE
ci: per-platform PyInstaller build + release workflow (#33)

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -86,6 +86,7 @@ jobs:
             --name "${{ matrix.binary }}" \
             --noconfirm \
             --collect-data wealthbox_tools \
+            --copy-metadata wealthbox-cli \
             scripts/wbox_entry.py
           test -f "dist/${{ matrix.binary }}"
           chmod +x "dist/${{ matrix.binary }}"
@@ -99,6 +100,7 @@ jobs:
             --name "${{ matrix.binary }}" `
             --noconfirm `
             --collect-data wealthbox_tools `
+            --copy-metadata wealthbox-cli `
             scripts/wbox_entry.py
           if (-not (Test-Path "dist/${{ matrix.binary }}")) {
             throw "expected dist/${{ matrix.binary }} to exist"

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -1,0 +1,215 @@
+# Per-platform PyInstaller build + GitHub Release upload.
+#
+# Triggered on v* tags (and manually via workflow_dispatch for fork
+# validation). Builds a single-file ``wbox`` binary for each of the four
+# supported targets, computes its SHA-256, and uploads the binaries plus
+# a combined manifest as assets on the GitHub Release for the tag.
+#
+# The PyPI publish job lives in ci.yml and is intentionally not touched
+# here — both workflows fire on ``v*`` tags but operate independently.
+#
+# ----------------------------------------------------------------------
+# Manifest contract (LOCKED — downstream consumers: issue #42 install.sh
+# rewrite, issue #43 install.ps1 parity)
+# ----------------------------------------------------------------------
+# Manifest filename: SHA256SUMS.txt
+# Format:            standard sha256sum-compatible. One record per line:
+#                    <hex-sha256><two-spaces><filename>
+# Sort order:        ASCII-sorted by filename (stable across runs)
+# Binary filenames:
+#   wbox-linux-x64
+#   wbox-macos-arm64
+#   wbox-macos-x64
+#   wbox-windows-x64.exe
+# Manifest assets are attached to the same GitHub Release as the four
+# binaries. Install scripts can fetch SHA256SUMS.txt and a single binary
+# from the same release URL prefix and verify the binary against the
+# matching line.
+# ----------------------------------------------------------------------
+
+name: Release Binaries
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: linux-x64
+            binary: wbox-linux-x64
+            shell: bash
+          - os: macos-13          # Intel runner (x86_64)
+            target: macos-x64
+            binary: wbox-macos-x64
+            shell: bash
+          - os: macos-14          # Apple Silicon runner (arm64)
+            target: macos-arm64
+            binary: wbox-macos-arm64
+            shell: bash
+          - os: windows-latest
+            target: windows-x64
+            binary: wbox-windows-x64.exe
+            shell: pwsh
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install runtime + build deps
+        shell: ${{ matrix.shell }}
+        run: |
+          python -m pip install --upgrade pip
+          pip install .
+          pip install pyinstaller
+
+      - name: Build single-file binary (Unix)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          pyinstaller \
+            --onefile \
+            --name "${{ matrix.binary }}" \
+            --noconfirm \
+            scripts/wbox_entry.py
+          test -f "dist/${{ matrix.binary }}"
+          chmod +x "dist/${{ matrix.binary }}"
+
+      - name: Build single-file binary (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          pyinstaller `
+            --onefile `
+            --name "${{ matrix.binary }}" `
+            --noconfirm `
+            scripts/wbox_entry.py
+          if (-not (Test-Path "dist/${{ matrix.binary }}")) {
+            throw "expected dist/${{ matrix.binary }} to exist"
+          }
+
+      - name: Smoke-test binary
+        shell: ${{ matrix.shell }}
+        run: |
+          ./dist/${{ matrix.binary }} --version
+
+      - name: Compute SHA-256 (Unix)
+        if: runner.os != 'Windows'
+        shell: bash
+        working-directory: dist
+        run: |
+          if command -v sha256sum >/dev/null 2>&1; then
+            sha256sum "${{ matrix.binary }}" > "${{ matrix.binary }}.sha256"
+          else
+            # macOS: shasum -a 256 emits sha256sum-compatible "<hash>  <name>"
+            shasum -a 256 "${{ matrix.binary }}" > "${{ matrix.binary }}.sha256"
+          fi
+          cat "${{ matrix.binary }}.sha256"
+
+      - name: Compute SHA-256 (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        working-directory: dist
+        run: |
+          $hash = (Get-FileHash -Algorithm SHA256 "${{ matrix.binary }}").Hash.ToLower()
+          # sha256sum format: "<hex>  <filename>" (two spaces, LF line ending)
+          $line = "$hash  ${{ matrix.binary }}`n"
+          [System.IO.File]::WriteAllText(
+            (Join-Path $PWD "${{ matrix.binary }}.sha256"),
+            $line
+          )
+          Get-Content "${{ matrix.binary }}.sha256"
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: wbox-${{ matrix.target }}
+          path: |
+            dist/${{ matrix.binary }}
+            dist/${{ matrix.binary }}.sha256
+          if-no-files-found: error
+          retention-days: 7
+
+  manifest-and-release:
+    name: Combine manifest and upload to release
+    needs: [build]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download all build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Stage release files
+        shell: bash
+        run: |
+          mkdir -p release
+          # Each artifact directory contains one binary + one .sha256 file.
+          find artifacts -type f \( -name 'wbox-*' -a ! -name '*.sha256' \) -exec cp -v {} release/ \;
+          find artifacts -type f -name '*.sha256' -exec cp -v {} release/ \;
+          ls -la release
+
+      - name: Build combined SHA256SUMS.txt
+        shell: bash
+        working-directory: release
+        run: |
+          # Concatenate per-binary sums into a single sha256sum-compatible
+          # manifest, ASCII-sorted by filename for stability.
+          # Each .sha256 file is already in "<hex>  <filename>" form.
+          cat *.sha256 | LC_ALL=C sort -k 2 > SHA256SUMS.txt
+          echo "----- SHA256SUMS.txt -----"
+          cat SHA256SUMS.txt
+          echo "--------------------------"
+          # Verify the manifest against the staged binaries as a sanity check.
+          sha256sum -c SHA256SUMS.txt
+
+      - name: Upload combined manifest artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: SHA256SUMS
+          path: release/SHA256SUMS.txt
+          if-no-files-found: error
+
+      - name: Upload assets to GitHub Release
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+          GH_REPO: ${{ github.repository }}
+        shell: bash
+        working-directory: release
+        run: |
+          # Ensure a release exists for the tag. If the PyPI publish job in
+          # ci.yml or a manual release-create created it first, --clobber on
+          # upload handles re-runs cleanly.
+          if ! gh release view "$TAG" >/dev/null 2>&1; then
+            gh release create "$TAG" \
+              --title "$TAG" \
+              --notes "Automated release for $TAG. Binaries built by release-binaries.yml; PyPI wheel published by ci.yml."
+          fi
+          # Upload all four binaries + the combined manifest. Per-platform
+          # .sha256 sidecars are intentionally not uploaded — SHA256SUMS.txt
+          # is the single source of truth for installers.
+          gh release upload "$TAG" \
+            wbox-linux-x64 \
+            wbox-macos-arm64 \
+            wbox-macos-x64 \
+            wbox-windows-x64.exe \
+            SHA256SUMS.txt \
+            --clobber

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -48,19 +48,15 @@ jobs:
           - os: ubuntu-latest
             target: linux-x64
             binary: wbox-linux-x64
-            shell: bash
           - os: macos-15-intel    # Intel runner (x86_64) — macos-13 was retired Dec 2025
             target: macos-x64
             binary: wbox-macos-x64
-            shell: bash
           - os: macos-14          # Apple Silicon runner (arm64)
             target: macos-arm64
             binary: wbox-macos-arm64
-            shell: bash
           - os: windows-latest
             target: windows-x64
             binary: wbox-windows-x64.exe
-            shell: pwsh
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -71,7 +67,6 @@ jobs:
           python-version: "3.12"
 
       - name: Install runtime + build deps
-        shell: ${{ matrix.shell }}
         run: |
           python -m pip install --upgrade pip
           pip install .
@@ -113,7 +108,6 @@ jobs:
         # this fails loudly if --collect-data wealthbox_tools didn't bundle
         # the skill template. Runs against the fresh runner HOME with
         # --no-bootstrap to skip the post-install confirm prompt.
-        shell: ${{ matrix.shell }}
         run: |
           ./dist/${{ matrix.binary }} --version
           ./dist/${{ matrix.binary }} skills install --platform claude-code-user --no-bootstrap

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -49,7 +49,7 @@ jobs:
             target: linux-x64
             binary: wbox-linux-x64
             shell: bash
-          - os: macos-13          # Intel runner (x86_64)
+          - os: macos-15-intel    # Intel runner (x86_64) — macos-13 was retired Dec 2025
             target: macos-x64
             binary: wbox-macos-x64
             shell: bash

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -85,6 +85,7 @@ jobs:
             --onefile \
             --name "${{ matrix.binary }}" \
             --noconfirm \
+            --collect-data wealthbox_tools \
             scripts/wbox_entry.py
           test -f "dist/${{ matrix.binary }}"
           chmod +x "dist/${{ matrix.binary }}"
@@ -97,15 +98,23 @@ jobs:
             --onefile `
             --name "${{ matrix.binary }}" `
             --noconfirm `
+            --collect-data wealthbox_tools `
             scripts/wbox_entry.py
           if (-not (Test-Path "dist/${{ matrix.binary }}")) {
             throw "expected dist/${{ matrix.binary }} to exist"
           }
 
       - name: Smoke-test binary
+        # `--version` only proves the entry point runs. `skills install`
+        # exercises bundled package data — it reads
+        # wealthbox_tools/skills/wealthbox-crm via importlib.resources — so
+        # this fails loudly if --collect-data wealthbox_tools didn't bundle
+        # the skill template. Runs against the fresh runner HOME with
+        # --no-bootstrap to skip the post-install confirm prompt.
         shell: ${{ matrix.shell }}
         run: |
           ./dist/${{ matrix.binary }} --version
+          ./dist/${{ matrix.binary }} skills install --platform claude-code-user --no-bootstrap
 
       - name: Compute SHA-256 (Unix)
         if: runner.os != 'Windows'

--- a/scripts/wbox_entry.py
+++ b/scripts/wbox_entry.py
@@ -1,0 +1,20 @@
+"""PyInstaller entry shim for the wbox CLI.
+
+PyInstaller's --onefile mode prefers a script file over a module:function
+console-script reference. This shim simply imports the Typer app defined
+at ``wealthbox_tools.cli.main:app`` and calls it, so the resulting binary
+behaves identically to the ``wbox`` console script registered in
+``pyproject.toml``.
+"""
+
+from __future__ import annotations
+
+from wealthbox_tools.cli.main import app
+
+
+def main() -> None:
+    app()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/release-binaries.yml`: a four-target PyInstaller matrix (`linux-x64`, `macos-x64`, `macos-arm64`, `windows-x64`) that runs on `v*` tags and `workflow_dispatch`, builds a single-file `wbox` binary per target, computes its SHA-256, and attaches the four binaries plus a combined `SHA256SUMS.txt` manifest to the GitHub Release for the tag.
- Adds `scripts/wbox_entry.py`: a tiny PyInstaller entry shim that imports and calls `wealthbox_tools.cli.main:app`. PyInstaller `--onefile` prefers a script file to a `module:function` reference, so the shim keeps the build invocation clean and avoids dynamic-import edge cases.
- The existing `publish` (PyPI) job in `ci.yml` is **untouched**, satisfying the trusted-publisher constraint in CLAUDE.md. Both workflows fire on `v*` tags and operate independently.

Closes #33.

## Manifest contract for #42 / #43

Downstream installer rewrites (#42 `install.sh`, #43 `install.ps1`) can rely on this contract being stable across releases:

- **Manifest filename:** `SHA256SUMS.txt`
- **Format:** standard `sha256sum`-compatible — one record per line, `<hex-sha256><two-spaces><filename>`
- **Sort order:** ASCII-sorted by filename (deterministic across runs)
- **Binary filenames:**
  - `wbox-linux-x64`
  - `wbox-macos-arm64`
  - `wbox-macos-x64`
  - `wbox-windows-x64.exe`
- **Asset location:** all four binaries plus `SHA256SUMS.txt` are uploaded to the same GitHub Release for the tag, so installers can fetch `<release-url>/<binary>` and `<release-url>/SHA256SUMS.txt` from the same prefix.

The contract is also documented in a header comment block at the top of `release-binaries.yml`.

## Design notes

- **New workflow file vs. extending `ci.yml`:** chose a separate file. The 4-target matrix would clutter `ci.yml`, the trigger filter (`v*` tags + `workflow_dispatch` only — no PRs) is cleaner in isolation, the PyPI `publish` job stays trivially untouched, and this workflow can be disabled or re-run independently when debugging.
- **Runner labels:** `macos-13` for Intel x64 and `macos-14` for Apple Silicon arm64. These are the conventional GitHub-hosted labels that produce the right native architecture without cross-compile.
- **Per-platform sums sidecar:** each matrix job emits a `<binary>.sha256` alongside its binary. The `manifest-and-release` job concatenates these into `SHA256SUMS.txt`, ASCII-sorts, and verifies with `sha256sum -c` before upload. The per-binary `.sha256` files are *not* uploaded as release assets — `SHA256SUMS.txt` is the single source of truth for installers.
- **Permissions:** matrix build jobs run with `contents: read`; only the `manifest-and-release` job is granted `contents: write` (needed for `gh release upload`).
- **Release creation:** the upload step creates the release if missing (idempotent), then uploads with `--clobber` so re-runs don't fail.
- **`workflow_dispatch` gating:** the upload step is gated on `if: startsWith(github.ref, 'refs/tags/')`. On a manual dispatch (no tag), the build + checksum + manifest-verify still run end-to-end, so the user can validate the whole pipeline without cutting a real release. A `SHA256SUMS` artifact is also uploaded for inspection.
- **Smoke test:** each binary runs `--version` before checksumming, so a broken build fails fast.

## Test plan

- [ ] User triggers `workflow_dispatch` on a fork; all four matrix jobs succeed and produce a binary + sidecar sum
- [ ] `manifest-and-release` job concatenates the four sidecars into `SHA256SUMS.txt` and the `sha256sum -c` verification passes
- [ ] On a real `v*` tag push, the four binaries + `SHA256SUMS.txt` appear as assets on the GitHub Release
- [ ] `ci.yml` `publish` job still runs and publishes to PyPI on the same tag (unchanged behaviour)

🤖 Generated with [Claude Code](https://claude.com/claude-code)