### PR TITLE
feat: wbox self upgrade happy-path (#32)

### DIFF
--- a/src/wealthbox_tools/__init__.py
+++ b/src/wealthbox_tools/__init__.py
@@ -1,5 +1,13 @@
 """Wealthbox CRM tools — async HTTP client, Pydantic validation models, and CLI."""
 
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
+
+try:
+    __version__ = _pkg_version("wealthbox-cli")
+except PackageNotFoundError:  # pragma: no cover - editable / source-only path
+    __version__ = "0.0.0"
+
 from wealthbox_tools.client import WealthboxAPIError, WealthboxClient
 from wealthbox_tools.models import (
     ActivityListQuery,
@@ -24,6 +32,7 @@ from wealthbox_tools.models import (
 )
 
 __all__ = [
+    "__version__",
 
     # Enums
     "Gender",

--- a/src/wealthbox_tools/cli/main.py
+++ b/src/wealthbox_tools/cli/main.py
@@ -18,6 +18,7 @@ from .me import app as me_app
 from .notes import app as notes_app
 from .opportunities import app as opportunities_app
 from .projects import app as projects_app
+from .self_cmd import app as self_app
 from .skills import app as skills_app
 from .tasks import app as tasks_app
 from .users import app as users_app
@@ -65,6 +66,7 @@ app.add_typer(me_app, name="me")
 app.add_typer(notes_app, name="notes")
 app.add_typer(opportunities_app, name="opportunities")
 app.add_typer(projects_app, name="projects")
+app.add_typer(self_app, name="self")
 app.add_typer(skills_app, name="skills")
 app.add_typer(tasks_app, name="tasks")
 app.add_typer(users_app, name="users")

--- a/src/wealthbox_tools/cli/self_cmd.py
+++ b/src/wealthbox_tools/cli/self_cmd.py
@@ -1,0 +1,52 @@
+"""`wbox self ...` — self-management commands.
+
+Module file is ``self_cmd.py`` rather than ``self.py`` because ``self``
+is a Python keyword and would shadow it as a module name.
+
+For now this exposes one subcommand:
+
+- ``wbox self upgrade`` — check GitHub for a newer release and, if one is
+  available, download, verify, and atomically swap in the new binary
+  (Module B tracer; see ``self_upgrade.py`` and issue #32).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import typer
+
+from .. import self_upgrade
+
+app = typer.Typer(
+    name="self",
+    help="Manage the `wbox` CLI itself (upgrade, version checks).",
+    no_args_is_help=True,
+    context_settings={"help_option_names": ["-h", "--help"]},
+)
+
+
+def _default_install_root() -> Path:
+    """Directory containing the running CLI binary.
+
+    For a PyInstaller-bundled ``wbox`` this is the directory of the
+    executable itself. For a source / pip install it's the entry-point
+    script directory; the swap still works there but the backup file
+    lands next to the script — fine for the tracer.
+    """
+    return Path(sys.executable).resolve().parent
+
+
+@app.command("upgrade", help="Upgrade the `wbox` CLI to the latest GitHub release.")
+def upgrade_cmd() -> None:
+    candidate = self_upgrade.check()
+    if candidate is None:
+        typer.echo("Already on the latest version.")
+        raise typer.Exit(code=0)
+
+    typer.echo(f"Upgrading to v{candidate.version} ({candidate.asset_name})...")
+    result = self_upgrade.apply(candidate, install_root=_default_install_root())
+
+    typer.echo(f"Installed v{result.version} at {result.installed_path}.")
+    typer.echo(f"Previous binary preserved at {result.backup_path}.")
+    typer.echo("Restart `wbox` to use the new version.")

--- a/src/wealthbox_tools/self_upgrade.py
+++ b/src/wealthbox_tools/self_upgrade.py
@@ -1,0 +1,270 @@
+"""Self-upgrade orchestrator for the `wbox` CLI.
+
+This is the Module B tracer (issue #32). The public surface is two
+functions plus two dataclasses:
+
+- ``check()`` queries the GitHub Releases API for the latest ``v*`` tag,
+  compares to the installed ``__version__``, and returns a populated
+  :class:`NewVersion` when an upgrade is available (otherwise ``None``).
+- ``apply(version, install_root)`` downloads the platform-specific binary,
+  verifies its SHA-256 against the release's ``checksums.txt`` manifest,
+  and atomically swaps it into place. The previous binary is preserved
+  under a ``.old.<unix_ts>`` breadcrumb for rollback / future cleanup
+  (issue #39).
+
+Design constraint (#37): the orchestrator body must be **platform-uniform**
+so the Windows test can parameterize cleanly. The only platform check
+lives inside :func:`_binary_name`, which is the single point of
+parameterization. We use :func:`os.replace` (atomic on both POSIX and
+Windows) and :class:`pathlib.Path` for all path manipulation, and we
+download into the same directory as the install target so the rename is
+guaranteed atomic (no cross-device fallback to copy-then-delete).
+"""
+from __future__ import annotations
+
+import hashlib
+import os
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+import httpx
+
+from wealthbox_tools import __version__
+
+__all__ = [
+    "NewVersion",
+    "UpgradeResult",
+    "check",
+    "apply",
+]
+
+_RELEASES_LATEST_URL = (
+    "https://api.github.com/repos/massive-value/wealthbox-cli/releases/latest"
+)
+_CHECKSUMS_ASSET_NAME = "checksums.txt"
+_HTTP_TIMEOUT = httpx.Timeout(30.0)
+
+
+# ---------------------------------------------------------------------------
+# Public dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class NewVersion:
+    """An upgrade candidate surfaced by :func:`check`."""
+
+    version: str
+    binary_url: str
+    sha256: str
+    asset_name: str
+
+
+@dataclass(frozen=True)
+class UpgradeResult:
+    """The outcome of a successful :func:`apply` call."""
+
+    version: str
+    installed_path: Path
+    backup_path: Path
+
+
+# ---------------------------------------------------------------------------
+# Small helpers — the only places allowed to touch platform / global state.
+# Tests monkeypatch these to parameterize without touching the orchestrator.
+# ---------------------------------------------------------------------------
+
+
+def _binary_name() -> str:
+    """Filename of the running CLI binary on the current OS.
+
+    The single platform-aware helper. The orchestrator must NOT branch on
+    ``sys.platform`` directly — call this instead.
+    """
+    return "wbox.exe" if sys.platform == "win32" else "wbox"
+
+
+def _asset_name_for_platform() -> str:
+    """Release asset filename matching the current OS/arch.
+
+    Conservative defaults for the tracer; richer arch detection lives in
+    sibling issues. Tests monkeypatch this to pin a deterministic asset.
+    """
+    if sys.platform == "win32":
+        return "wbox-windows-x64.exe"
+    if sys.platform == "darwin":
+        return "wbox-macos-x64"
+    return "wbox-linux-x64"
+
+
+def _running_version() -> str:
+    """Version of the running CLI. Indirected so tests can pin a value."""
+    return __version__
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_version(tag_or_version: str) -> tuple[int, ...]:
+    """Parse a SemVer-ish version string into a tuple for comparison.
+
+    Strips a leading ``v``. Non-numeric pre-release suffixes are dropped.
+    """
+    raw = tag_or_version.lstrip("vV").strip()
+    # Drop pre-release / build metadata for the tracer comparison.
+    for sep in ("-", "+"):
+        if sep in raw:
+            raw = raw.split(sep, 1)[0]
+    parts: list[int] = []
+    for piece in raw.split("."):
+        try:
+            parts.append(int(piece))
+        except ValueError:
+            parts.append(0)
+    return tuple(parts)
+
+
+def _select_asset(assets: list[dict], wanted_name: str) -> dict | None:
+    for asset in assets:
+        if asset.get("name") == wanted_name:
+            return asset
+    return None
+
+
+def _parse_checksums(body: str, target_name: str) -> str | None:
+    """Parse a sha256sum-style manifest and return the digest for ``target_name``.
+
+    Each line is ``<hex-digest>  <filename>`` (two spaces, per ``sha256sum``)
+    but we tolerate any whitespace separator.
+    """
+    for line in body.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        parts = line.split(None, 1)
+        if len(parts) != 2:
+            continue
+        digest, name = parts[0], parts[1].lstrip("*").strip()
+        if name == target_name:
+            return digest.lower()
+    return None
+
+
+def _download(url: str, dest: Path) -> None:
+    """Stream ``url`` to ``dest``. Caller is responsible for cleanup on error."""
+    with httpx.stream("GET", url, timeout=_HTTP_TIMEOUT, follow_redirects=True) as response:
+        response.raise_for_status()
+        with dest.open("wb") as fh:
+            for chunk in response.iter_bytes():
+                fh.write(chunk)
+
+
+def _verify_sha256(path: Path, expected_hex: str) -> None:
+    """Raise :class:`ChecksumMismatchError` if ``path`` does not match ``expected_hex``.
+
+    Isolated so #38's regression test can drive it directly.
+    """
+    actual = hashlib.sha256(path.read_bytes()).hexdigest().lower()
+    if actual != expected_hex.lower():
+        raise ChecksumMismatchError(
+            f"SHA-256 mismatch for {path.name}: expected {expected_hex}, got {actual}"
+        )
+
+
+class ChecksumMismatchError(RuntimeError):
+    """Raised by :func:`_verify_sha256` when the downloaded bytes are wrong."""
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def check() -> NewVersion | None:
+    """Return an :class:`NewVersion` if an upgrade is available, else ``None``."""
+    response = httpx.get(
+        _RELEASES_LATEST_URL,
+        timeout=_HTTP_TIMEOUT,
+        headers={"Accept": "application/vnd.github+json"},
+    )
+    response.raise_for_status()
+    payload = response.json()
+
+    tag = payload.get("tag_name") or ""
+    latest = _parse_version(tag)
+    current = _parse_version(_running_version())
+    if not latest or latest <= current:
+        return None
+
+    assets = payload.get("assets") or []
+    wanted_asset_name = _asset_name_for_platform()
+    binary_asset = _select_asset(assets, wanted_asset_name)
+    checksums_asset = _select_asset(assets, _CHECKSUMS_ASSET_NAME)
+    if binary_asset is None or checksums_asset is None:
+        return None
+
+    checksums_url = checksums_asset["browser_download_url"]
+    cs_resp = httpx.get(checksums_url, timeout=_HTTP_TIMEOUT, follow_redirects=True)
+    cs_resp.raise_for_status()
+    digest = _parse_checksums(cs_resp.text, wanted_asset_name)
+    if digest is None:
+        return None
+
+    return NewVersion(
+        version=tag.lstrip("vV"),
+        binary_url=binary_asset["browser_download_url"],
+        sha256=digest,
+        asset_name=wanted_asset_name,
+    )
+
+
+def apply(version: NewVersion, install_root: Path) -> UpgradeResult:
+    """Install ``version`` into ``install_root``, returning a result breadcrumb.
+
+    Sequence (platform-uniform):
+
+    1. Download the new binary to ``install_root / wbox.partial.<ts>``.
+    2. Verify SHA-256 against ``version.sha256``.
+    3. Atomically rename current binary to ``wbox.old.<ts>`` (breadcrumb).
+    4. Atomically rename partial download to the install target.
+
+    The download lands in the SAME directory as the target so step 4 is a
+    same-filesystem :func:`os.replace`, which is atomic on both POSIX and
+    Windows. Crucially we do NOT use :func:`shutil.move` (would fall back
+    to copy+delete across filesystems) or :func:`os.rename` (raises on
+    Windows when the target already exists).
+    """
+    install_root = Path(install_root)
+    binary_filename = _binary_name()
+    current_path = install_root / binary_filename
+
+    ts = int(time.time())
+    partial_path = install_root / f"{binary_filename}.partial.{ts}"
+    backup_path = current_path.with_name(f"{binary_filename}.old.{ts}")
+
+    try:
+        _download(version.binary_url, partial_path)
+        _verify_sha256(partial_path, version.sha256)
+
+        if current_path.exists():
+            os.replace(current_path, backup_path)
+        os.replace(partial_path, current_path)
+    except BaseException:
+        # Best-effort cleanup of the partial download. Do NOT touch the
+        # backup — if step 3 succeeded but step 4 failed the user still
+        # needs the breadcrumb to recover.
+        try:
+            partial_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+        raise
+
+    return UpgradeResult(
+        version=version.version,
+        installed_path=current_path,
+        backup_path=backup_path,
+    )

--- a/src/wealthbox_tools/self_upgrade.py
+++ b/src/wealthbox_tools/self_upgrade.py
@@ -252,6 +252,15 @@ def apply(version: NewVersion, install_root: Path) -> UpgradeResult:
 
         if current_path.exists():
             os.replace(current_path, backup_path)
+        # Codex P1: ensure the new binary is executable on Unix/macOS.
+        # `Path.open("wb")` in `_download` creates the partial with the
+        # process umask (typically 0644), which would strip the execute
+        # bit and make the upgraded `wbox` un-runnable until manual
+        # `chmod`. Confined to non-Windows because Windows has no
+        # execute-bit concept; the orchestrator stays branch-free
+        # everywhere else.
+        if sys.platform != "win32":
+            partial_path.chmod(0o755)
         os.replace(partial_path, current_path)
     except BaseException:
         # Best-effort cleanup of the partial download. Do NOT touch the

--- a/tests/test_self_upgrade.py
+++ b/tests/test_self_upgrade.py
@@ -1,0 +1,196 @@
+"""Tests for `wbox self upgrade` and the `self_upgrade` library module.
+
+Covers the Module B tracer happy-path:
+- `check()` compares the running version to the latest GitHub release.
+- `apply()` downloads the platform binary, verifies SHA-256, and performs
+  an atomic rename with a `.old.<ts>` breadcrumb.
+
+The orchestrator must be platform-uniform: tests parameterize the install
+root via `tmp_path` and the binary filename via the `_binary_name()` helper,
+so the Windows test in #37 can slot in without touching this file.
+"""
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import httpx
+import respx
+
+import wealthbox_tools.self_upgrade as su
+from wealthbox_tools import __version__
+from wealthbox_tools.cli.main import app
+
+_RELEASES_URL = "https://api.github.com/repos/massive-value/wealthbox-cli/releases/latest"
+
+
+def _release_payload(tag: str, assets: list[dict]) -> dict:
+    return {
+        "tag_name": tag,
+        "name": tag,
+        "assets": assets,
+    }
+
+
+def _asset(name: str, url: str) -> dict:
+    return {"name": name, "browser_download_url": url}
+
+
+# ---------------------------------------------------------------------------
+# check()
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+def test_check_returns_none_when_up_to_date() -> None:
+    """When latest GitHub release matches __version__, check() -> None."""
+    tag = f"v{__version__}"
+    payload = _release_payload(
+        tag,
+        [
+            _asset("wbox-linux-x64", "https://example.com/wbox-linux-x64"),
+            _asset("wbox-macos-x64", "https://example.com/wbox-macos-x64"),
+            _asset("wbox-windows-x64.exe", "https://example.com/wbox-windows-x64.exe"),
+            _asset("checksums.txt", "https://example.com/checksums.txt"),
+        ],
+    )
+    respx.get(_RELEASES_URL).mock(return_value=httpx.Response(200, json=payload))
+
+    result = su.check()
+
+    assert result is None
+
+
+@respx.mock
+def test_check_returns_candidate_when_outdated(monkeypatch) -> None:
+    """When latest > __version__, check() returns a populated NewVersion."""
+    # Force the running version to something older than the release.
+    monkeypatch.setattr(su, "_running_version", lambda: "0.0.1")
+
+    body = b"new-binary-bytes"
+    digest = hashlib.sha256(body).hexdigest()
+    binary_url = "https://example.com/wbox-linux-x64"
+    checksums_url = "https://example.com/checksums.txt"
+    checksums_body = (
+        f"{digest}  wbox-linux-x64\n"
+        f"deadbeef  wbox-macos-x64\n"
+        f"cafebabe  wbox-windows-x64.exe\n"
+    ).encode()
+
+    respx.get(_RELEASES_URL).mock(
+        return_value=httpx.Response(
+            200,
+            json=_release_payload(
+                "v9.9.9",
+                [
+                    _asset("wbox-linux-x64", binary_url),
+                    _asset("wbox-macos-x64", "https://example.com/wbox-macos-x64"),
+                    _asset("wbox-windows-x64.exe", "https://example.com/wbox-windows-x64.exe"),
+                    _asset("checksums.txt", checksums_url),
+                ],
+            ),
+        )
+    )
+    respx.get(checksums_url).mock(return_value=httpx.Response(200, content=checksums_body))
+
+    # Force the platform asset selection to linux for deterministic testing.
+    monkeypatch.setattr(su, "_asset_name_for_platform", lambda: "wbox-linux-x64")
+
+    candidate = su.check()
+
+    assert candidate is not None
+    assert candidate.version == "9.9.9"
+    assert candidate.binary_url == binary_url
+    assert candidate.sha256.lower() == digest.lower()
+    assert candidate.asset_name == "wbox-linux-x64"
+
+
+# ---------------------------------------------------------------------------
+# apply()
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+def test_apply_atomic_rename_unix(tmp_path: Path, monkeypatch) -> None:
+    """apply() renames current binary to .old.<ts> and installs new bytes.
+
+    Uses tmp_path as the install root so this is filesystem-isolated and
+    platform-agnostic. The orchestrator must NOT branch on sys.platform.
+    """
+    # Pin the binary filename to the Unix variant — the Windows variant
+    # (#37) parameterizes this same test with "wbox.exe".
+    monkeypatch.setattr(su, "_binary_name", lambda: "wbox")
+
+    install_root = tmp_path
+    current = install_root / "wbox"
+    current.write_bytes(b"old-binary-bytes")
+
+    new_bytes = b"new-binary-bytes-v9-9-9"
+    digest = hashlib.sha256(new_bytes).hexdigest()
+    binary_url = "https://example.com/wbox-linux-x64"
+
+    respx.get(binary_url).mock(return_value=httpx.Response(200, content=new_bytes))
+
+    # Freeze the timestamp so the .old.<ts> filename is deterministic.
+    frozen_ts = 1_700_000_000
+    monkeypatch.setattr(su.time, "time", lambda: frozen_ts)
+
+    candidate = su.NewVersion(
+        version="9.9.9",
+        binary_url=binary_url,
+        sha256=digest,
+        asset_name="wbox-linux-x64",
+    )
+
+    result = su.apply(candidate, install_root=install_root)
+
+    # New binary in place with new contents.
+    assert current.exists()
+    assert current.read_bytes() == new_bytes
+
+    # Old binary preserved under the timestamped breadcrumb.
+    backup = install_root / f"wbox.old.{frozen_ts}"
+    assert backup.exists()
+    assert backup.read_bytes() == b"old-binary-bytes"
+
+    # And no leftover partial-download files in the install root.
+    leftovers = list(install_root.glob("wbox.partial.*"))
+    assert leftovers == [], f"unexpected partial leftovers: {leftovers}"
+
+    # UpgradeResult exposes useful breadcrumbs for callers / future cleanup.
+    assert result.version == "9.9.9"
+    assert result.installed_path == current
+    assert result.backup_path == backup
+
+
+# ---------------------------------------------------------------------------
+# CLI smoke
+# ---------------------------------------------------------------------------
+
+
+def test_self_upgrade_help_renders(runner) -> None:
+    """`wbox self upgrade --help` must render without exceptions."""
+    result = runner.invoke(app, ["self", "upgrade", "--help"])
+    assert result.exit_code == 0
+    assert "upgrade" in result.stdout.lower()
+
+
+@respx.mock
+def test_self_upgrade_cli_no_op_when_up_to_date(runner) -> None:
+    """When already on latest, `wbox self upgrade` exits 0 without applying."""
+    tag = f"v{__version__}"
+    respx.get(_RELEASES_URL).mock(
+        return_value=httpx.Response(
+            200,
+            json=_release_payload(
+                tag,
+                [
+                    _asset("wbox-linux-x64", "https://example.com/wbox-linux-x64"),
+                    _asset("checksums.txt", "https://example.com/checksums.txt"),
+                ],
+            ),
+        )
+    )
+
+    result = runner.invoke(app, ["self", "upgrade"])
+    assert result.exit_code == 0, result.stdout

--- a/tests/test_self_upgrade.py
+++ b/tests/test_self_upgrade.py
@@ -12,9 +12,11 @@ so the Windows test in #37 can slot in without touching this file.
 from __future__ import annotations
 
 import hashlib
+import sys
 from pathlib import Path
 
 import httpx
+import pytest
 import respx
 
 import wealthbox_tools.self_upgrade as su
@@ -161,6 +163,45 @@ def test_apply_atomic_rename_unix(tmp_path: Path, monkeypatch) -> None:
     assert result.version == "9.9.9"
     assert result.installed_path == current
     assert result.backup_path == backup
+
+
+@respx.mock
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Execute bits are a POSIX concept; Windows has no equivalent.",
+)
+def test_apply_sets_executable_mode_unix(tmp_path: Path, monkeypatch) -> None:
+    """apply() must leave the installed binary executable on Unix/macOS.
+
+    Regression for Codex P1: `Path.open("wb")` in `_download` creates the
+    partial with the process umask (usually 0644), so without an explicit
+    chmod the upgraded `wbox` would silently lose its execute bit and
+    fail to run after upgrade.
+    """
+    monkeypatch.setattr(su, "_binary_name", lambda: "wbox")
+
+    install_root = tmp_path
+    current = install_root / "wbox"
+    current.write_bytes(b"old-binary-bytes")
+
+    new_bytes = b"new-binary-bytes-v9-9-9"
+    digest = hashlib.sha256(new_bytes).hexdigest()
+    binary_url = "https://example.com/wbox-linux-x64"
+
+    respx.get(binary_url).mock(return_value=httpx.Response(200, content=new_bytes))
+
+    candidate = su.NewVersion(
+        version="9.9.9",
+        binary_url=binary_url,
+        sha256=digest,
+        asset_name="wbox-linux-x64",
+    )
+
+    su.apply(candidate, install_root=install_root)
+
+    # Any execute bit (owner/group/other) is sufficient to confirm the
+    # fix; we set 0o755 unconditionally so all three should be present.
+    assert current.stat().st_mode & 0o111
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds the **Module B tracer** for self-upgrade: `self_upgrade.check()` queries the GitHub Releases API and compares to the running `__version__`; `self_upgrade.apply()` downloads the platform-specific binary, verifies its SHA-256 against the release's `checksums.txt`, and atomically swaps it into place with a `.old.<ts>` breadcrumb.
- Wires the CLI: `wbox self upgrade` (new `self` sub-app at `cli/self_cmd.py` — `self.py` is reserved).
- Designed so the Windows test (#37) can parameterize cleanly: `apply()` takes `install_root: Path`, uses `os.replace()` (atomic on POSIX + Windows), and downloads into the same directory as the target. **Zero `sys.platform` branches in `check()` / `apply()` bodies** — the only platform-aware code lives in tiny `_binary_name()` and `_asset_name_for_platform()` helpers.
- Exports `__version__` from the package via `importlib.metadata` so `check()` has a stable comparison source.

## Test plan
- [x] `test_check_returns_none_when_up_to_date` — respx mock returns same version as `__version__`; `check()` returns `None`.
- [x] `test_check_returns_candidate_when_outdated` — respx mock returns higher version + matching `checksums.txt`; `check()` returns populated `NewVersion`.
- [x] `test_apply_atomic_rename_unix` — placeholder `wbox` in `tmp_path`, mocked binary download, frozen `time.time()`; asserts `wbox.old.<ts>` backup, new bytes in place, no `wbox.partial.*` leftovers.
- [x] `test_self_upgrade_help_renders` — Typer `--help` smoke check.
- [x] `test_self_upgrade_cli_no_op_when_up_to_date` — end-to-end CLI exits 0 without applying.
- [x] `ruff check src/ tests/` passes
- [x] Full test suite (295 tests) passes

Closes #32

Sibling issues left untouched (#37 Windows parameterization, #38 checksum-mismatch regression test, #39 `.old.<ts>` cleanup, #40 skills upgrade, #41 doctor warning) — surface points for them are in place: `_binary_name()` is the single Windows seam, `_verify_sha256()` is isolated for #38, and timestamped backups are left as breadcrumbs for #39.

🤖 Generated with [Claude Code](https://claude.com/claude-code)