### PR TITLE
feat: add user preferences slot and wbox prefs commands (#29)

### DIFF
--- a/src/wealthbox_tools/cli/_config.py
+++ b/src/wealthbox_tools/cli/_config.py
@@ -20,6 +20,20 @@ def _config_path() -> pathlib.Path:
     return _config_dir() / "config.json"
 
 
+def _user_dir() -> pathlib.Path:
+    """Return the L3 user-preferences directory (sibling of the firm dir)."""
+    return _config_dir() / "user"
+
+
+def _user_prefs_path() -> pathlib.Path:
+    """Return the absolute path to the user's ``preferences.md`` file.
+
+    The file may be empty or absent — callers must not assume it exists.
+    The directory is hand-edited; ``wbox`` never writes to it implicitly.
+    """
+    return _user_dir() / "preferences.md"
+
+
 def load_config() -> dict[str, Any]:
     """Load config from disk. Returns empty dict if file doesn't exist."""
     path = _config_path()

--- a/src/wealthbox_tools/cli/_config.py
+++ b/src/wealthbox_tools/cli/_config.py
@@ -21,8 +21,17 @@ def _config_path() -> pathlib.Path:
 
 
 def _user_dir() -> pathlib.Path:
-    """Return the L3 user-preferences directory (sibling of the firm dir)."""
-    return _config_dir() / "user"
+    """Return the L3 user-preferences directory (sibling of the firm dir).
+
+    Always returns an absolute path: ``_config_dir()`` honours
+    ``XDG_CONFIG_HOME`` / ``APPDATA`` verbatim, which can be set to a
+    relative value. The ``prefs path`` / helper contract guarantees an
+    absolute result regardless of the caller's current working directory,
+    so we resolve here. (``_config_dir()`` itself is intentionally left
+    alone — it has many existing consumers and changing its semantics is
+    out of scope for the prefs slot.)
+    """
+    return (_config_dir() / "user").resolve()
 
 
 def _user_prefs_path() -> pathlib.Path:
@@ -30,6 +39,7 @@ def _user_prefs_path() -> pathlib.Path:
 
     The file may be empty or absent — callers must not assume it exists.
     The directory is hand-edited; ``wbox`` never writes to it implicitly.
+    Absolute-ness is inherited from ``_user_dir()``.
     """
     return _user_dir() / "preferences.md"
 

--- a/src/wealthbox_tools/cli/main.py
+++ b/src/wealthbox_tools/cli/main.py
@@ -17,6 +17,7 @@ from .internals import app as internals_app
 from .me import app as me_app
 from .notes import app as notes_app
 from .opportunities import app as opportunities_app
+from .prefs import app as prefs_app
 from .projects import app as projects_app
 from .skills import app as skills_app
 from .tasks import app as tasks_app
@@ -64,6 +65,7 @@ app.add_typer(internals_app, name="internals", hidden=True)
 app.add_typer(me_app, name="me")
 app.add_typer(notes_app, name="notes")
 app.add_typer(opportunities_app, name="opportunities")
+app.add_typer(prefs_app, name="prefs")
 app.add_typer(projects_app, name="projects")
 app.add_typer(skills_app, name="skills")
 app.add_typer(tasks_app, name="tasks")

--- a/src/wealthbox_tools/cli/prefs.py
+++ b/src/wealthbox_tools/cli/prefs.py
@@ -1,0 +1,44 @@
+"""User-preferences (L3) commands.
+
+The L3 user layer lives at ``~/.config/wbox/user/preferences.md`` (or
+``%APPDATA%\\wbox\\user\\preferences.md`` on Windows) — a sibling of the
+L2 firm directory. The file is hand-edited; in v2 there is no schema and
+``wbox`` never writes to it implicitly. Agents may read it via these
+commands and (with user confirmation) edit it directly.
+"""
+from __future__ import annotations
+
+import sys
+
+import typer
+
+from ._config import _user_prefs_path
+
+app = typer.Typer(
+    context_settings={"help_option_names": ["-h", "--help"]},
+    help="Read the user-preferences file (~/.config/wbox/user/preferences.md).",
+    no_args_is_help=True,
+)
+
+
+@app.command("path", help="Print the absolute path to preferences.md.")
+def path_cmd() -> None:
+    typer.echo(str(_user_prefs_path()))
+
+
+@app.command(
+    "show",
+    help=(
+        "Print the contents of preferences.md. "
+        "Exits 0 with empty output if the file or its parent directory "
+        "is absent — the file is optional."
+    ),
+)
+def show_cmd() -> None:
+    prefs_path = _user_prefs_path()
+    if not prefs_path.exists():
+        return
+    # Stream raw bytes to stdout to preserve the file's exact contents
+    # (including trailing newlines and encoding) without typer's nl=True
+    # appending an extra newline.
+    sys.stdout.write(prefs_path.read_text(encoding="utf-8"))

--- a/tests/test_prefs.py
+++ b/tests/test_prefs.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import os
+import platform
+from pathlib import Path
+
+from wealthbox_tools.cli.main import app
+
+
+def test_prefs_path_prints_canonical_path(tmp_path, monkeypatch, runner):
+    """`wbox prefs path` prints the absolute preferences.md path on the current OS."""
+    # Hermetic: redirect both XDG_CONFIG_HOME and APPDATA so the test never
+    # touches the developer's real config dir.
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setenv("APPDATA", str(tmp_path))
+
+    result = runner.invoke(app, ["prefs", "path"])
+    assert result.exit_code == 0
+
+    expected = tmp_path / "wbox" / "user" / "preferences.md"
+    printed = result.stdout.strip()
+    assert printed == str(expected)
+    # Path must be absolute regardless of OS/cwd.
+    assert os.path.isabs(printed)
+
+
+def test_prefs_path_uses_appdata_on_windows(tmp_path, monkeypatch, runner):
+    """On Windows the path must be rooted under %APPDATA%\\wbox\\user."""
+    if platform.system() != "Windows":
+        # The helper inspects platform.system() at call time, so this branch
+        # only meaningfully exercises the Windows code path on Windows.
+        return
+    monkeypatch.setenv("APPDATA", str(tmp_path))
+
+    result = runner.invoke(app, ["prefs", "path"])
+    assert result.exit_code == 0
+    assert result.stdout.strip() == str(tmp_path / "wbox" / "user" / "preferences.md")
+
+
+def test_prefs_show_prints_contents_when_file_exists(tmp_path, monkeypatch, runner):
+    """`wbox prefs show` dumps preferences.md contents when present."""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setenv("APPDATA", str(tmp_path))
+
+    user_dir = tmp_path / "wbox" / "user"
+    user_dir.mkdir(parents=True)
+    body = "# My prefs\n\n- favorite_color: blue\n"
+    (user_dir / "preferences.md").write_text(body, encoding="utf-8")
+
+    result = runner.invoke(app, ["prefs", "show"])
+    assert result.exit_code == 0
+    assert result.stdout == body
+
+
+def test_prefs_show_empty_when_file_absent(tmp_path, monkeypatch, runner):
+    """`wbox prefs show` exits 0 with empty stdout if the file is missing."""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setenv("APPDATA", str(tmp_path))
+
+    # Create the user dir but no preferences.md inside it.
+    (tmp_path / "wbox" / "user").mkdir(parents=True)
+
+    result = runner.invoke(app, ["prefs", "show"])
+    assert result.exit_code == 0
+    assert result.stdout == ""
+
+
+def test_prefs_show_empty_when_parent_dir_absent(tmp_path, monkeypatch, runner):
+    """`wbox prefs show` exits 0 with empty stdout if the parent dir is missing."""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setenv("APPDATA", str(tmp_path))
+
+    # No wbox/ at all.
+    assert not (tmp_path / "wbox").exists()
+
+    result = runner.invoke(app, ["prefs", "show"])
+    assert result.exit_code == 0
+    assert result.stdout == ""
+
+
+def test_prefs_show_does_not_create_user_dir(tmp_path, monkeypatch, runner):
+    """`wbox prefs show` must be read-only — no side effects on disk."""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setenv("APPDATA", str(tmp_path))
+
+    result = runner.invoke(app, ["prefs", "show"])
+    assert result.exit_code == 0
+    # Confirm `show` did not lazily create the directory tree.
+    assert not (tmp_path / "wbox" / "user").exists()
+
+
+def test_prefs_path_does_not_create_user_dir(tmp_path, monkeypatch, runner):
+    """`wbox prefs path` must not create the user directory."""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setenv("APPDATA", str(tmp_path))
+
+    result = runner.invoke(app, ["prefs", "path"])
+    assert result.exit_code == 0
+    assert not (tmp_path / "wbox" / "user").exists()
+
+
+def test_user_prefs_path_helper_matches_config_dir():
+    """The helper used by `prefs` must mirror `_config_dir()` exactly."""
+    from wealthbox_tools.cli._config import _config_dir, _user_prefs_path
+
+    assert _user_prefs_path() == _config_dir() / "user" / "preferences.md"
+    assert isinstance(_user_prefs_path(), Path)

--- a/tests/test_prefs.py
+++ b/tests/test_prefs.py
@@ -17,7 +17,9 @@ def test_prefs_path_prints_canonical_path(tmp_path, monkeypatch, runner):
     result = runner.invoke(app, ["prefs", "path"])
     assert result.exit_code == 0
 
-    expected = tmp_path / "wbox" / "user" / "preferences.md"
+    # _user_dir() resolves the path, which may canonicalise symlinks on
+    # platforms where tmp_path lives under one (e.g. macOS /var → /private/var).
+    expected = (tmp_path / "wbox" / "user").resolve() / "preferences.md"
     printed = result.stdout.strip()
     assert printed == str(expected)
     # Path must be absolute regardless of OS/cwd.
@@ -34,7 +36,8 @@ def test_prefs_path_uses_appdata_on_windows(tmp_path, monkeypatch, runner):
 
     result = runner.invoke(app, ["prefs", "path"])
     assert result.exit_code == 0
-    assert result.stdout.strip() == str(tmp_path / "wbox" / "user" / "preferences.md")
+    expected = (tmp_path / "wbox" / "user").resolve() / "preferences.md"
+    assert result.stdout.strip() == str(expected)
 
 
 def test_prefs_show_prints_contents_when_file_exists(tmp_path, monkeypatch, runner):
@@ -100,8 +103,42 @@ def test_prefs_path_does_not_create_user_dir(tmp_path, monkeypatch, runner):
 
 
 def test_user_prefs_path_helper_matches_config_dir():
-    """The helper used by `prefs` must mirror `_config_dir()` exactly."""
+    """The helper used by `prefs` must mirror `_config_dir()` exactly.
+
+    _user_dir() applies .resolve() to guarantee an absolute path even when
+    XDG_CONFIG_HOME / APPDATA is set to a relative value, so we compare
+    against the resolved equivalent here.
+    """
     from wealthbox_tools.cli._config import _config_dir, _user_prefs_path
 
-    assert _user_prefs_path() == _config_dir() / "user" / "preferences.md"
+    expected = (_config_dir() / "user").resolve() / "preferences.md"
+    assert _user_prefs_path() == expected
     assert isinstance(_user_prefs_path(), Path)
+
+
+def test_prefs_path_is_absolute_when_xdg_relative(tmp_path, monkeypatch, runner):
+    """`wbox prefs path` must print an absolute path even when the env var is relative.
+
+    Codex P2 (PR #66): if XDG_CONFIG_HOME / APPDATA is set to a relative
+    value, the underlying _config_dir() preserves that base, so the prefs
+    helpers would otherwise return a path that depends on the caller's cwd.
+    The new prefs slot's contract guarantees an absolute path; verify that
+    by chdir'ing into a tmp dir and pointing the env var at a relative
+    sibling directory.
+    """
+    # Run from inside tmp_path so a relative env var is interpretable but
+    # the meaning depends on cwd (which is exactly what we want to defeat).
+    monkeypatch.chdir(tmp_path)
+    # "rel-config" is a relative path — without .resolve() in the helper,
+    # _user_prefs_path() would return Path("rel-config/wbox/user/preferences.md").
+    monkeypatch.setenv("XDG_CONFIG_HOME", "rel-config")
+    monkeypatch.setenv("APPDATA", "rel-config")
+
+    result = runner.invoke(app, ["prefs", "path"])
+    assert result.exit_code == 0
+
+    printed = result.stdout.strip()
+    assert Path(printed).is_absolute(), f"expected absolute path, got: {printed!r}"
+    # The resolved path must point inside our tmp_path (cwd) — confirms the
+    # relative base was anchored to cwd at resolve time.
+    assert printed.endswith(str(Path("rel-config") / "wbox" / "user" / "preferences.md"))


### PR DESCRIPTION
## Summary

Introduces the L3 user-preferences layer as a sibling of the L2 firm directory:

- Mac/Linux: `~/.config/wbox/user/preferences.md`
- Windows:   `%APPDATA%\wbox\user\preferences.md`

Adds two read-only CLI commands in a new `cli/prefs.py` module:

- `wbox prefs path` -- print the absolute path to `preferences.md` on stdout
- `wbox prefs show` -- print contents on stdout, exit 0 with empty output if the file or its parent directory is absent

In v2 there is no schema -- the markdown is the schema. The file is hand-edited; agents may write to it with user confirmation. No `set` / `unset` commands are exposed (deliberately out of scope).

The new helpers `_user_dir()` and `_user_prefs_path()` live in `cli/_config.py` next to `_config_dir()` so the OS branching stays in one place; `cli/prefs.py` only consumes them. `cli/main.py` registers the new sub-app between `opportunities` and `projects`.

### No-write acceptance check

Confirmed by inspection that no firm-import / firm-export / skill-install code path writes under `~/.config/wbox/user/`:

- `cli/_skill_paths.py::firm_dir()` resolves to `_config_dir() / "firm"` only.
- `firm/archive.py` operates on a caller-supplied `firm_dir` and includes a docstring note that `~/.config/wbox/user/` is unreachable from it by construction.
- `grep -r 'user'` across the `firm/` and `skills/` packages returns only the new prefs module and the existing archive docstring -- no writers.

Sibling issue #34 will document this layer in the skill template's `SKILL.md`. This PR deliberately does not touch `SKILL.md`.

Closes #29

## Test plan

- [x] `ruff check src/ tests/` passes
- [x] `pytest -q` passes (298 passed, includes 8 new tests in `tests/test_prefs.py`)
- [x] `wbox prefs path` prints the canonical path (covered + asserts `os.path.isabs`)
- [x] `wbox prefs show` prints contents when file exists
- [x] `wbox prefs show` exits 0 with empty output when file is absent
- [x] `wbox prefs show` exits 0 with empty output when parent directory is absent
- [x] `wbox prefs show` and `wbox prefs path` do not lazily create the user dir
- [x] `_user_prefs_path()` mirrors `_config_dir() / "user" / "preferences.md"`