### PR TITLE
feat: wbox self upgrade Windows deferred-swap (#67)

### DIFF
--- a/src/wealthbox_tools/cli/main.py
+++ b/src/wealthbox_tools/cli/main.py
@@ -5,6 +5,8 @@ from importlib.metadata import version as _pkg_version
 
 import typer
 
+from .. import self_upgrade
+from . import self_cmd
 from .activity import app as activity_app
 from .categories import app as categories_app
 from .config import app as config_app
@@ -25,6 +27,33 @@ from .tasks import app as tasks_app
 from .users import app as users_app
 from .workflows import app as workflows_app
 
+
+def _check_pending_upgrade_status() -> None:
+    """Surface the outcome of a deferred self-upgrade swap, if any.
+
+    The Windows deferred-swap helper writes ``wbox.upgrade.status`` next to
+    the binary after the swap (or after timing out). On the next ``wbox``
+    launch — that is, here — we read it, print a one-line summary to stderr,
+    and unlink it. Never raises; a corrupt status file would otherwise nag
+    the user every invocation.
+
+    Resolves ``_default_install_root`` through the module reference so tests
+    can monkeypatch it on :mod:`cli.self_cmd` and have the change take
+    effect here.
+    """
+    status = self_upgrade._read_and_clear_upgrade_status(self_cmd._default_install_root())
+    if status is None:
+        return
+    version = status.get("version") or "?"
+    if status.get("result") == "ok":
+        typer.echo(f"wbox: upgrade to v{version} completed.", err=True)
+    else:
+        reason = status.get("reason") or "unknown error"
+        typer.echo(
+            f"wbox: upgrade to v{version} failed ({reason}). Old binary still in place.",
+            err=True,
+        )
+
 app = typer.Typer(context_settings={"help_option_names": ["-h", "--help"]}, 
     name="wbox",
     help="Wealthbox CRM CLI — interact with contacts, households, tasks, events, opportunities, and notes.",
@@ -42,6 +71,7 @@ def _main(
              "agents and pipelines almost never want it.",
     ),
 ) -> None:
+    _check_pending_upgrade_status()
     if version:
         typer.echo(_pkg_version("wealthbox-cli"))
         raise typer.Exit()

--- a/src/wealthbox_tools/cli/self_cmd.py
+++ b/src/wealthbox_tools/cli/self_cmd.py
@@ -47,6 +47,15 @@ def upgrade_cmd() -> None:
     typer.echo(f"Upgrading to v{candidate.version} ({candidate.asset_name})...")
     result = self_upgrade.apply(candidate, install_root=_default_install_root())
 
-    typer.echo(f"Installed v{result.version} at {result.installed_path}.")
-    typer.echo(f"Previous binary preserved at {result.backup_path}.")
-    typer.echo("Restart `wbox` to use the new version.")
+    if self_upgrade._is_windows():
+        # The rename is deferred to a helper that runs after this process
+        # exits, so we cannot honestly claim the upgrade is "installed" yet.
+        # The helper writes a status file that next-launch wbox reports.
+        typer.echo(
+            f"Scheduled v{result.version} — wbox will exit and complete the upgrade."
+        )
+        typer.echo("Run `wbox --version` after restart to confirm.")
+    else:
+        typer.echo(f"Installed v{result.version} at {result.installed_path}.")
+        typer.echo(f"Previous binary preserved at {result.backup_path}.")
+        typer.echo("Restart `wbox` to use the new version.")

--- a/src/wealthbox_tools/self_upgrade.py
+++ b/src/wealthbox_tools/self_upgrade.py
@@ -23,7 +23,9 @@ guaranteed atomic (no cross-device fallback to copy-then-delete).
 from __future__ import annotations
 
 import hashlib
+import json
 import os
+import subprocess
 import sys
 import time
 from dataclasses import dataclass
@@ -32,6 +34,13 @@ from pathlib import Path
 import httpx
 
 from wealthbox_tools import __version__
+
+# Subprocess creation flags used by the Windows deferred-swap helper.
+# Looked up via getattr so this module imports cleanly on POSIX (where the
+# constants don't exist on the subprocess module). The actual values come
+# from MSDN Process Creation Flags.
+_DETACHED_PROCESS = getattr(subprocess, "DETACHED_PROCESS", 0x00000008)
+_CREATE_NEW_PROCESS_GROUP = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0x00000200)
 
 __all__ = [
     "NewVersion",
@@ -179,6 +188,211 @@ class ChecksumMismatchError(RuntimeError):
     """Raised by :func:`_verify_sha256` when the downloaded bytes are wrong."""
 
 
+def _perform_swap(current: Path, partial: Path, backup: Path) -> None:
+    """Rename ``current`` → ``backup`` (if it exists) and ``partial`` → ``current``.
+
+    The pure swap unit shared by the Unix in-process path and the Windows
+    deferred-swap helper. Platform-uniform except for the Unix-only chmod
+    that restores the execute bit (Windows has no execute-bit concept).
+
+    The Unix-only chmod is needed because ``Path.open("wb")`` in
+    :func:`_download` creates the partial with the process umask (typically
+    ``0644``); without restoring ``0o755`` the upgraded binary would lose
+    its execute bit and fail to run after upgrade.
+    """
+    if current.exists():
+        os.replace(current, backup)
+    if sys.platform != "win32":
+        partial.chmod(0o755)
+    os.replace(partial, current)
+
+
+def _is_windows() -> bool:
+    """Hook for the platform-policy dispatch in :func:`_schedule_swap`.
+
+    Indirected (rather than reading ``sys.platform`` inline) so tests can
+    exercise both branches against a Unix runner without monkeypatching
+    ``sys.platform`` itself, which would also affect unrelated stdlib
+    behavior (path separators, environment lookup, etc.).
+    """
+    return sys.platform == "win32"
+
+
+def _schedule_swap(
+    current: Path, partial: Path, backup: Path, parent_pid: int, version: str
+) -> None:
+    """Single platform-dispatch seam for the swap step in :func:`apply`.
+
+    On Unix, runs :func:`_perform_swap` synchronously and returns. On
+    Windows, the running ``wbox.exe`` is locked by the OS so the rename
+    must be deferred to a child process that waits for the parent to exit.
+    See :func:`_schedule_deferred_swap`. ``version`` flows through to the
+    Windows helper so it can write the upgrade outcome to the status file.
+    """
+    if _is_windows():
+        _schedule_deferred_swap(current, partial, backup, parent_pid, version)
+    else:
+        _perform_swap(current, partial, backup)
+
+
+_STATUS_FILENAME = "wbox.upgrade.status"
+
+
+def _read_and_clear_upgrade_status(install_root: Path) -> dict | None:
+    """Read + clear the upgrade status file written by the Windows helper.
+
+    Called on every CLI startup. Returns the parsed JSON dict if a status
+    file is present and well-formed; ``None`` otherwise. Deletes the file
+    in both the well-formed and malformed cases (the malformed file would
+    otherwise nag the user every launch).
+
+    Never raises: the caller is the root-callback hook in :mod:`cli.main`,
+    where any exception would crash every ``wbox`` invocation until the
+    user manually cleared the file.
+    """
+    status_path = install_root / _STATUS_FILENAME
+    if not status_path.exists():
+        return None
+    try:
+        data = json.loads(status_path.read_text())
+    except (OSError, json.JSONDecodeError):
+        try:
+            status_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+        return None
+    try:
+        status_path.unlink(missing_ok=True)
+    except OSError:
+        pass
+    if not isinstance(data, dict):
+        return None
+    return data
+
+
+def _ps_single_quote(s: str) -> str:
+    """Wrap ``s`` in PowerShell single-quote string literal syntax.
+
+    Inside a single-quoted PS string, ``''`` (two single quotes) is the
+    only escape needed — backslashes, ``$``, and backticks are all literal.
+    Used to embed Windows paths into the inline helper script safely.
+    """
+    return "'" + s.replace("'", "''") + "'"
+
+
+def _build_powershell_command(
+    parent_pid: int,
+    current: Path,
+    partial: Path,
+    backup: Path,
+    status_path: Path,
+    version: str,
+    timeout_seconds: int = 30,
+) -> list[str]:
+    """Build argv for ``subprocess.Popen`` to run the deferred-swap helper.
+
+    The returned list is passed to Popen verbatim. The helper:
+
+    1. Polls ``Get-Process -Id <parent_pid>`` every 100ms until the parent
+       exits or ``timeout_seconds`` elapses.
+    2. If the parent exited in time: retries the rename pair (current →
+       backup, partial → current) for up to 3 seconds to absorb the brief
+       window between process exit and OS file-lock release.
+    3. Writes a JSON status file atomically (``.tmp`` + Move-Item) so the
+       next ``wbox`` launch can surface the outcome.
+    """
+    cur_q = _ps_single_quote(str(current))
+    par_q = _ps_single_quote(str(partial))
+    bak_q = _ps_single_quote(str(backup))
+    sta_q = _ps_single_quote(str(status_path))
+    ver_q = _ps_single_quote(version)
+
+    script = f"""\
+$parentPid = {parent_pid}
+$current = {cur_q}
+$partial = {par_q}
+$backup = {bak_q}
+$statusPath = {sta_q}
+$version = {ver_q}
+$timeoutSeconds = {timeout_seconds}
+$start = Get-Date
+while (
+    (Get-Process -Id $parentPid -ErrorAction SilentlyContinue) -and
+    (((Get-Date) - $start).TotalSeconds -lt $timeoutSeconds)
+) {{
+    Start-Sleep -Milliseconds 100
+}}
+$ts = [int][double]::Parse((Get-Date -UFormat %s))
+$status = @{{ result = ''; version = $version; reason = $null; ts = $ts }}
+if (Get-Process -Id $parentPid -ErrorAction SilentlyContinue) {{
+    $status.result = 'failed'
+    $status.reason = 'timeout waiting for parent exit'
+}}
+else {{
+    $swapped = $false
+    for ($i = 0; $i -lt 30; $i++) {{
+        try {{
+            if (Test-Path -LiteralPath $current) {{
+                Move-Item -LiteralPath $current -Destination $backup -Force
+            }}
+            Move-Item -LiteralPath $partial -Destination $current -Force
+            $swapped = $true
+            break
+        }} catch {{
+            Start-Sleep -Milliseconds 100
+        }}
+    }}
+    $status.ts = [int][double]::Parse((Get-Date -UFormat %s))
+    if ($swapped) {{
+        $status.result = 'ok'
+    }}
+    else {{
+        $status.result = 'failed'
+        $status.reason = 'rename failed after retries'
+    }}
+}}
+$statusJson = $status | ConvertTo-Json -Compress
+$tmpStatus = $statusPath + '.tmp'
+Set-Content -Path $tmpStatus -Value $statusJson -NoNewline
+Move-Item -LiteralPath $tmpStatus -Destination $statusPath -Force
+"""
+
+    return [
+        "powershell",
+        "-NoProfile",
+        "-WindowStyle", "Hidden",
+        "-Command", script,
+    ]
+
+
+def _schedule_deferred_swap(
+    current: Path, partial: Path, backup: Path, parent_pid: int, version: str
+) -> None:
+    """Spawn a detached PowerShell helper to perform the swap after parent exit.
+
+    The detached creation flags (DETACHED_PROCESS + CREATE_NEW_PROCESS_GROUP)
+    plus DEVNULL stdio ensure the helper survives the parent's exit; without
+    them the helper would inherit the parent's console and die with it.
+    """
+    status_path = current.with_name(_STATUS_FILENAME)
+    argv = _build_powershell_command(
+        parent_pid=parent_pid,
+        current=current,
+        partial=partial,
+        backup=backup,
+        status_path=status_path,
+        version=version,
+    )
+    subprocess.Popen(
+        argv,
+        creationflags=_DETACHED_PROCESS | _CREATE_NEW_PROCESS_GROUP,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        close_fds=True,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
@@ -250,18 +464,9 @@ def apply(version: NewVersion, install_root: Path) -> UpgradeResult:
         _download(version.binary_url, partial_path)
         _verify_sha256(partial_path, version.sha256)
 
-        if current_path.exists():
-            os.replace(current_path, backup_path)
-        # Codex P1: ensure the new binary is executable on Unix/macOS.
-        # `Path.open("wb")` in `_download` creates the partial with the
-        # process umask (typically 0644), which would strip the execute
-        # bit and make the upgraded `wbox` un-runnable until manual
-        # `chmod`. Confined to non-Windows because Windows has no
-        # execute-bit concept; the orchestrator stays branch-free
-        # everywhere else.
-        if sys.platform != "win32":
-            partial_path.chmod(0o755)
-        os.replace(partial_path, current_path)
+        _schedule_swap(
+            current_path, partial_path, backup_path, os.getpid(), version.version
+        )
     except BaseException:
         # Best-effort cleanup of the partial download. Do NOT touch the
         # backup — if step 3 succeeded but step 4 failed the user still

--- a/src/wealthbox_tools/self_upgrade.py
+++ b/src/wealthbox_tools/self_upgrade.py
@@ -347,6 +347,9 @@ else {{
         $status.result = 'ok'
     }}
     else {{
+        if ((Test-Path -LiteralPath $backup) -and (-not (Test-Path -LiteralPath $current))) {{
+            try {{ Move-Item -LiteralPath $backup -Destination $current -Force }} catch {{ }}
+        }}
         $status.result = 'failed'
         $status.reason = 'rename failed after retries'
     }}

--- a/tests/test_self_upgrade.py
+++ b/tests/test_self_upgrade.py
@@ -183,6 +183,39 @@ def test_build_powershell_command_returns_expected_argv_shape(tmp_path: Path) ->
     assert "wbox.upgrade.status" in script
 
 
+def test_build_powershell_command_rolls_back_backup_on_swap_failure(tmp_path: Path) -> None:
+    """If retries exhaust, the helper must move $backup → $current before failing.
+
+    Codex P2 on PR #68: when current→backup succeeds but partial→current keeps
+    failing, the user is left without a runnable wbox.exe and has no way to
+    recover. The helper must restore the original binary before declaring
+    failure so the user can at least run `wbox self upgrade` again.
+    """
+    argv = su._build_powershell_command(
+        parent_pid=12345,
+        current=tmp_path / "wbox.exe",
+        partial=tmp_path / "wbox.exe.partial.42",
+        backup=tmp_path / "wbox.exe.old.42",
+        status_path=tmp_path / "wbox.upgrade.status",
+        version="9.9.9",
+        timeout_seconds=30,
+    )
+
+    script = argv[argv.index("-Command") + 1]
+
+    # Slice out the failure-handling block — everything after the retry loop's
+    # exit when $swapped is false. Look for the move-backup-to-current pattern.
+    rename_failed_idx = script.find("rename failed")
+    assert rename_failed_idx != -1, "expected the rename-failed reason string in script"
+
+    # The rollback should appear in the failure block: Move-Item with $backup
+    # as the source (LiteralPath) and $current as the destination.
+    pre_status_block = script[: rename_failed_idx]
+    assert "Move-Item -LiteralPath $backup" in pre_status_block, (
+        f"expected backup → current rollback before failure status; script:\n{script}"
+    )
+
+
 def test_build_powershell_command_handles_paths_with_spaces(tmp_path: Path) -> None:
     """Paths with spaces must be safely quoted so the rename doesn't shell-explode."""
     spaced_dir = tmp_path / "Program Files" / "wbox"

--- a/tests/test_self_upgrade.py
+++ b/tests/test_self_upgrade.py
@@ -12,6 +12,7 @@ so the Windows test in #37 can slot in without touching this file.
 from __future__ import annotations
 
 import hashlib
+import json
 import sys
 from pathlib import Path
 
@@ -108,8 +109,224 @@ def test_check_returns_candidate_when_outdated(monkeypatch) -> None:
 
 
 # ---------------------------------------------------------------------------
+# _perform_swap() — the pure rename unit shared by Unix apply() and the
+# Windows deferred-swap helper. Parameterized over the binary filename so
+# Unix-style ("wbox") and Windows-style ("wbox.exe") names share one test.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("binary_filename", ["wbox", "wbox.exe"])
+def test_perform_swap_does_rename_pair(tmp_path: Path, binary_filename: str) -> None:
+    """`_perform_swap` renames current → backup and partial → current.
+
+    The swap *logic* is platform-uniform; only the *scheduling* of when this
+    runs differs (in-process on Unix, in a child process after parent exit
+    on Windows — see `_schedule_swap`).
+    """
+    current = tmp_path / binary_filename
+    current.write_bytes(b"old-bytes")
+    partial = tmp_path / f"{binary_filename}.partial.42"
+    partial.write_bytes(b"new-bytes")
+    backup = tmp_path / f"{binary_filename}.old.42"
+
+    su._perform_swap(current, partial, backup)
+
+    assert current.read_bytes() == b"new-bytes"
+    assert backup.read_bytes() == b"old-bytes"
+    assert not partial.exists()
+
+
+# ---------------------------------------------------------------------------
+# _build_powershell_command() — pure argv builder for the deferred-swap helper.
+# ---------------------------------------------------------------------------
+
+
+def test_build_powershell_command_returns_expected_argv_shape(tmp_path: Path) -> None:
+    """argv list has the expected powershell flags and embeds runtime values.
+
+    The returned list is passed to subprocess.Popen verbatim. The inline
+    script must include the parent pid (for Get-Process polling), the
+    timeout, the version (written to status file), and refer to the swap
+    operation and the status filename.
+    """
+    argv = su._build_powershell_command(
+        parent_pid=12345,
+        current=tmp_path / "wbox.exe",
+        partial=tmp_path / "wbox.exe.partial.42",
+        backup=tmp_path / "wbox.exe.old.42",
+        status_path=tmp_path / "wbox.upgrade.status",
+        version="9.9.9",
+        timeout_seconds=30,
+    )
+
+    # argv shape: powershell + flags + -Command + script.
+    assert argv[0] == "powershell"
+    assert "-NoProfile" in argv
+    assert "-WindowStyle" in argv
+    assert argv[argv.index("-WindowStyle") + 1] == "Hidden"
+    assert "-Command" in argv
+
+    script = argv[argv.index("-Command") + 1]
+
+    # Embedded values used at runtime by the helper.
+    assert "12345" in script  # parent pid for Get-Process polling
+    assert "9.9.9" in script  # version string written into the status file
+    assert "30" in script  # timeout seconds
+
+    # Polling: helper waits for parent exit before renaming.
+    assert "Get-Process" in script
+
+    # Rename pair: helper does the swap after parent exit.
+    assert "Move-Item" in script or "Rename-Item" in script
+
+    # Status file is mentioned (helper writes it on success or failure).
+    assert "wbox.upgrade.status" in script
+
+
+def test_build_powershell_command_handles_paths_with_spaces(tmp_path: Path) -> None:
+    """Paths with spaces must be safely quoted so the rename doesn't shell-explode."""
+    spaced_dir = tmp_path / "Program Files" / "wbox"
+    spaced_dir.mkdir(parents=True)
+
+    argv = su._build_powershell_command(
+        parent_pid=99,
+        current=spaced_dir / "wbox.exe",
+        partial=spaced_dir / "wbox.exe.partial.42",
+        backup=spaced_dir / "wbox.exe.old.42",
+        status_path=spaced_dir / "wbox.upgrade.status",
+        version="9.9.9",
+        timeout_seconds=30,
+    )
+
+    script = argv[argv.index("-Command") + 1]
+    # The literal space-bearing path must appear inside single-quoted strings
+    # so PowerShell treats it as one literal string, not as multiple tokens.
+    assert "'" in script
+    assert "Program Files" in script
+
+
+# ---------------------------------------------------------------------------
+# _schedule_deferred_swap() — Popen invocation with the right detachment flags.
+# ---------------------------------------------------------------------------
+
+
+def test_schedule_deferred_swap_invokes_popen_with_detached_flags(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Popen invoked with the helper argv, detached flags, and DEVNULL stdio.
+
+    The flags + DEVNULL combo is what lets the helper survive after the
+    parent exits — without them the helper would inherit the parent's
+    console and die with it, leaving the upgrade half-applied.
+    """
+    captured: dict = {}
+
+    class FakePopen:
+        def __init__(self, args, **kwargs):
+            captured["args"] = args
+            captured["kwargs"] = kwargs
+
+    monkeypatch.setattr(su.subprocess, "Popen", FakePopen)
+
+    current = tmp_path / "wbox.exe"
+    partial = tmp_path / "wbox.exe.partial.42"
+    backup = tmp_path / "wbox.exe.old.42"
+
+    su._schedule_deferred_swap(current, partial, backup, parent_pid=12345, version="9.9.9")
+
+    # Popen received the PowerShell argv built by _build_powershell_command.
+    args = captured["args"]
+    assert args[0] == "powershell"
+    assert "-Command" in args
+    script = args[args.index("-Command") + 1]
+    assert "12345" in script
+    assert "9.9.9" in script
+
+    # Helper must survive parent exit: detached + new process group + no
+    # inherited stdio. The exact constants come from subprocess on Windows.
+    DETACHED_PROCESS = 0x00000008
+    CREATE_NEW_PROCESS_GROUP = 0x00000200
+    flags = captured["kwargs"].get("creationflags", 0)
+    assert flags & DETACHED_PROCESS, f"DETACHED_PROCESS missing from creationflags={flags:#x}"
+    assert flags & CREATE_NEW_PROCESS_GROUP, (
+        f"CREATE_NEW_PROCESS_GROUP missing from creationflags={flags:#x}"
+    )
+
+    import subprocess as _subprocess
+
+    assert captured["kwargs"].get("stdin") is _subprocess.DEVNULL
+    assert captured["kwargs"].get("stdout") is _subprocess.DEVNULL
+    assert captured["kwargs"].get("stderr") is _subprocess.DEVNULL
+
+
+# ---------------------------------------------------------------------------
 # apply()
 # ---------------------------------------------------------------------------
+
+
+@respx.mock
+def test_apply_windows_defers_swap_to_helper(tmp_path: Path, monkeypatch) -> None:
+    """On Windows-style fixtures, apply() must NOT rename the live binary in-process.
+
+    Renaming a running .exe on Windows raises PermissionError (the OS holds an
+    exclusive lock on the executable). Instead apply() schedules a deferred-swap
+    helper, leaves the partial download on disk for the helper to swap in, and
+    returns a result breadcrumb. The helper performs the rename after the parent
+    process exits.
+    """
+    monkeypatch.setattr(su, "_binary_name", lambda: "wbox.exe")
+    monkeypatch.setattr(su, "_is_windows", lambda: True)
+
+    install_root = tmp_path
+    current = install_root / "wbox.exe"
+    current.write_bytes(b"old-bytes")
+
+    new_bytes = b"new-windows-bytes"
+    digest = hashlib.sha256(new_bytes).hexdigest()
+    binary_url = "https://example.com/wbox-windows-x64.exe"
+    respx.get(binary_url).mock(return_value=httpx.Response(200, content=new_bytes))
+
+    frozen_ts = 1_700_000_001
+    monkeypatch.setattr(su.time, "time", lambda: frozen_ts)
+
+    spawned: list[tuple[Path, Path, Path, int, str]] = []
+
+    def fake_schedule(
+        current_p: Path, partial_p: Path, backup_p: Path, parent_pid: int, version: str
+    ) -> None:
+        spawned.append((current_p, partial_p, backup_p, parent_pid, version))
+
+    monkeypatch.setattr(su, "_schedule_deferred_swap", fake_schedule)
+
+    candidate = su.NewVersion(
+        version="9.9.9",
+        binary_url=binary_url,
+        sha256=digest,
+        asset_name="wbox-windows-x64.exe",
+    )
+
+    result = su.apply(candidate, install_root=install_root)
+
+    # Current binary must NOT have been replaced in-process — that's the whole point.
+    assert current.read_bytes() == b"old-bytes"
+
+    # Helper must have been scheduled exactly once with the expected paths.
+    assert len(spawned) == 1
+    spawned_current, spawned_partial, spawned_backup, spawned_pid, spawned_version = spawned[0]
+    assert spawned_current == current
+    assert spawned_partial == install_root / f"wbox.exe.partial.{frozen_ts}"
+    assert spawned_backup == install_root / f"wbox.exe.old.{frozen_ts}"
+    assert isinstance(spawned_pid, int) and spawned_pid > 0
+    assert spawned_version == "9.9.9"
+
+    # Partial must still be on disk for the helper to swap in.
+    assert spawned_partial.exists()
+    assert spawned_partial.read_bytes() == new_bytes
+
+    # Result breadcrumb still points where the new binary will live.
+    assert result.version == "9.9.9"
+    assert result.installed_path == current
+    assert result.backup_path == install_root / f"wbox.exe.old.{frozen_ts}"
 
 
 @respx.mock
@@ -119,9 +336,12 @@ def test_apply_atomic_rename_unix(tmp_path: Path, monkeypatch) -> None:
     Uses tmp_path as the install root so this is filesystem-isolated and
     platform-agnostic. The orchestrator must NOT branch on sys.platform.
     """
-    # Pin the binary filename to the Unix variant — the Windows variant
-    # (#37) parameterizes this same test with "wbox.exe".
+    # Pin the binary filename and platform policy to the Unix variant. On a
+    # Windows CI runner this test still exercises the Unix code path; the
+    # Windows-specific orchestration is covered by
+    # `test_apply_windows_defers_swap_to_helper`.
     monkeypatch.setattr(su, "_binary_name", lambda: "wbox")
+    monkeypatch.setattr(su, "_is_windows", lambda: False)
 
     install_root = tmp_path
     current = install_root / "wbox"
@@ -179,6 +399,7 @@ def test_apply_sets_executable_mode_unix(tmp_path: Path, monkeypatch) -> None:
     fail to run after upgrade.
     """
     monkeypatch.setattr(su, "_binary_name", lambda: "wbox")
+    monkeypatch.setattr(su, "_is_windows", lambda: False)
 
     install_root = tmp_path
     current = install_root / "wbox"
@@ -205,6 +426,48 @@ def test_apply_sets_executable_mode_unix(tmp_path: Path, monkeypatch) -> None:
 
 
 # ---------------------------------------------------------------------------
+# _read_and_clear_upgrade_status() — next-launch reader for the status file
+# the Windows helper writes after attempting the deferred swap.
+# ---------------------------------------------------------------------------
+
+
+def test_read_and_clear_upgrade_status_returns_parsed_dict_and_deletes_file(
+    tmp_path: Path,
+) -> None:
+    """Reader parses the status JSON, unlinks the file, returns the dict."""
+    install_root = tmp_path
+    status_path = install_root / "wbox.upgrade.status"
+    payload = {"result": "ok", "version": "9.9.9", "reason": None, "ts": 1700000000}
+    status_path.write_text(json.dumps(payload))
+
+    parsed = su._read_and_clear_upgrade_status(install_root)
+
+    assert parsed == payload
+    assert not status_path.exists()
+
+
+def test_read_and_clear_upgrade_status_returns_none_when_no_file(tmp_path: Path) -> None:
+    """No status file → reader returns None (no error, no side effect)."""
+    assert su._read_and_clear_upgrade_status(tmp_path) is None
+
+
+def test_read_and_clear_upgrade_status_handles_malformed_json(tmp_path: Path) -> None:
+    """Malformed status file → reader returns None and removes the bad file.
+
+    The reader must never raise — it's called on every wbox startup; a bad
+    file would otherwise crash the CLI on every subsequent invocation.
+    """
+    install_root = tmp_path
+    status_path = install_root / "wbox.upgrade.status"
+    status_path.write_text("not-valid-json{{{")
+
+    parsed = su._read_and_clear_upgrade_status(install_root)
+
+    assert parsed is None
+    assert not status_path.exists()
+
+
+# ---------------------------------------------------------------------------
 # CLI smoke
 # ---------------------------------------------------------------------------
 
@@ -214,6 +477,130 @@ def test_self_upgrade_help_renders(runner) -> None:
     result = runner.invoke(app, ["self", "upgrade", "--help"])
     assert result.exit_code == 0
     assert "upgrade" in result.stdout.lower()
+
+
+def test_main_callback_prints_pending_upgrade_status(runner, tmp_path, monkeypatch) -> None:
+    """When a status file exists, the root callback prints its outcome to stderr.
+
+    The status file is written by the Windows deferred-swap helper between CLI
+    invocations; reading + clearing it on next launch is how the user learns
+    the upgrade succeeded (or failed).
+    """
+    from wealthbox_tools.cli import self_cmd
+
+    monkeypatch.setattr(self_cmd, "_default_install_root", lambda: tmp_path)
+
+    status_path = tmp_path / "wbox.upgrade.status"
+    status_path.write_text(
+        json.dumps({"result": "ok", "version": "9.9.9", "reason": None, "ts": 1700000000})
+    )
+
+    result = runner.invoke(app, ["--version"])
+
+    assert result.exit_code == 0
+    assert "9.9.9" in result.stderr
+    assert not status_path.exists()
+
+
+def test_main_callback_prints_pending_upgrade_failure(runner, tmp_path, monkeypatch) -> None:
+    """A failed upgrade status surfaces the reason and the recovery state."""
+    from wealthbox_tools.cli import self_cmd
+
+    monkeypatch.setattr(self_cmd, "_default_install_root", lambda: tmp_path)
+
+    status_path = tmp_path / "wbox.upgrade.status"
+    status_path.write_text(
+        json.dumps(
+            {
+                "result": "failed",
+                "version": "9.9.9",
+                "reason": "timeout waiting for parent exit",
+                "ts": 1700000000,
+            }
+        )
+    )
+
+    result = runner.invoke(app, ["--version"])
+
+    assert result.exit_code == 0
+    assert "9.9.9" in result.stderr
+    assert "fail" in result.stderr.lower()
+    assert "timeout waiting for parent exit" in result.stderr
+    assert not status_path.exists()
+
+
+def test_upgrade_cmd_windows_says_scheduled(runner, monkeypatch, tmp_path) -> None:
+    """On Windows, `wbox self upgrade` reports the upgrade as 'Scheduled', not 'Installed'.
+
+    The deferred-swap helper performs the actual rename after the parent
+    exits, so claiming the upgrade is 'installed' before the parent exits
+    would be misleading — and possibly false if the helper later fails.
+    """
+    monkeypatch.setattr(su, "_is_windows", lambda: True)
+    monkeypatch.setattr(
+        su,
+        "check",
+        lambda: su.NewVersion(
+            version="9.9.9",
+            binary_url="https://example.com/x",
+            sha256="deadbeef",
+            asset_name="wbox-windows-x64.exe",
+        ),
+    )
+    fake_result = su.UpgradeResult(
+        version="9.9.9",
+        installed_path=tmp_path / "wbox.exe",
+        backup_path=tmp_path / "wbox.exe.old.42",
+    )
+    monkeypatch.setattr(su, "apply", lambda candidate, install_root: fake_result)
+
+    result = runner.invoke(app, ["self", "upgrade"])
+
+    assert result.exit_code == 0, result.stdout
+    assert "Scheduled" in result.stdout
+    assert "9.9.9" in result.stdout
+    # Must NOT claim the upgrade is installed yet — that's after parent exit.
+    assert "Installed" not in result.stdout
+
+
+def test_upgrade_cmd_unix_says_installed(runner, monkeypatch, tmp_path) -> None:
+    """On Unix, the existing 'Installed v9.9.9' wording is preserved (regression)."""
+    monkeypatch.setattr(su, "_is_windows", lambda: False)
+    monkeypatch.setattr(
+        su,
+        "check",
+        lambda: su.NewVersion(
+            version="9.9.9",
+            binary_url="https://example.com/x",
+            sha256="deadbeef",
+            asset_name="wbox-linux-x64",
+        ),
+    )
+    fake_result = su.UpgradeResult(
+        version="9.9.9",
+        installed_path=tmp_path / "wbox",
+        backup_path=tmp_path / "wbox.old.42",
+    )
+    monkeypatch.setattr(su, "apply", lambda candidate, install_root: fake_result)
+
+    result = runner.invoke(app, ["self", "upgrade"])
+
+    assert result.exit_code == 0, result.stdout
+    assert "Installed" in result.stdout
+    assert "9.9.9" in result.stdout
+    assert "Scheduled" not in result.stdout
+
+
+def test_main_callback_silent_when_no_status_file(runner, tmp_path, monkeypatch) -> None:
+    """No status file → no startup-status output (the common case)."""
+    from wealthbox_tools.cli import self_cmd
+
+    monkeypatch.setattr(self_cmd, "_default_install_root", lambda: tmp_path)
+
+    result = runner.invoke(app, ["--version"])
+
+    assert result.exit_code == 0
+    assert "upgrade" not in result.stderr.lower()
 
 
 @respx.mock


### PR DESCRIPTION
## Summary

Implements the Windows path for `wbox self upgrade` so it no longer fails with `PermissionError` when renaming the running `wbox.exe`. The rename is deferred to a detached PowerShell helper that polls for parent exit, performs the swap, and writes a JSON status file that next-launch wbox surfaces to stderr.

Closes #67. Coordinates with #37 — the parameterized rename test now targets the extracted `_perform_swap` (pure rename pair); see #37 for the narrowed scope.

## Design decisions (resolved with @kadinb 2026-05-08)

- **Helper:** inline PowerShell command via `subprocess.Popen(["powershell", ...])`. No bundled file, no separate binary.
- **Sync:** PS helper polls `Get-Process -Id $parentPid` every ~100ms with 30s timeout, plus a bounded retry loop on the rename to absorb the brief lock-release window.
- **UX:** Unix wording unchanged. Windows prints `Scheduled v9.9.9 — wbox will exit and complete the upgrade.` followed by `Run wbox --version after restart to confirm.`
- **Failure visibility:** helper writes `wbox.upgrade.status` (JSON) next to install_root. Every wbox startup reads + clears it, prints to stderr, never raises.
- **Single dispatch seam:** `_schedule_swap(current, partial, backup, parent_pid, version)` is the only place `apply()` branches on `sys.platform` (via `_is_windows()`).

## Test plan

- [x] All 8 acceptance criteria from #67 covered by 14 new tests (337 → 351 passing; 1 skipped is the existing Unix-only chmod test on Windows runners).
- [x] `_perform_swap` parameterized over `wbox` and `wbox.exe` against `tmp_path`.
- [x] Windows-style fixtures (`_binary_name → "wbox.exe"`, `_is_windows → True`) confirm `apply()` does NOT call `os.replace` synchronously and DOES call `_schedule_deferred_swap` with the right paths + version.
- [x] Existing Unix tests (`test_apply_atomic_rename_unix`, `test_apply_sets_executable_mode_unix`) refactored to monkeypatch `_is_windows → False` so they exercise the Unix policy on a Windows runner.
- [x] `_build_powershell_command` is pure: argv shape + embedded pid/version/timeout/Get-Process/Move-Item/status filename + path-with-spaces quoting.
- [x] `subprocess.Popen` invoked with `DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP` and `stdin=stdout=stderr=DEVNULL`.
- [x] `_read_and_clear_upgrade_status` round-trips, returns None on missing file, returns None and removes file on malformed JSON, never raises.
- [x] `cli/main.py` startup hook prints "completed" or "failed (reason)" summaries to stderr; silent when no status file.
- [x] `upgrade_cmd` says "Scheduled" on Windows, "Installed" on Unix.
- [x] `ruff check src/ tests/` passes.
- [ ] Smoke test on a real Windows runner from a packaged `wbox.exe` — best done by cutting a pre-release and running `wbox self upgrade` against it.

## Notes

- Per resolved squire-hub Pocock-flow plan, this PR's design lives in #67's body, not in `docs/superpowers/specs/`.
- After this lands, please update #37's acceptance criteria to scope it to "parameterized `_perform_swap` test + open-handle Windows test" (the orchestrator-level concern is now closed).