### PR TITLE
feat: stale .old.<ts> backup cleanup (#39)

### DIFF
--- a/src/wealthbox_tools/cli/doctor.py
+++ b/src/wealthbox_tools/cli/doctor.py
@@ -14,6 +14,7 @@ from importlib.metadata import version as _pkg_version
 
 import typer
 
+from .. import self_upgrade
 from ._config import _config_path, load_config
 from ._skill_bootstrap import migrate_legacy_firm, read_firm_meta, read_meta
 from ._skill_paths import firm_dir, firm_meta_path
@@ -23,6 +24,7 @@ from ._skill_platforms import (
     is_installed,
     skill_dir,
 )
+from .self_cmd import _default_install_root
 
 
 def _detect_token_source(token_arg: str | None) -> tuple[str | None, str]:
@@ -176,6 +178,24 @@ def run_doctor(token: str | None = None) -> int:
                     typer.echo(f"  oldest:   {oldest}")
                 except (ValueError, TypeError):
                     pass
+
+    # --- Self-upgrade backups --------------------------------------------
+    # Sweep stale `<binary>.old.<ts>` rollback breadcrumbs (#39). Same
+    # 24h threshold as `apply()` — doctor is the second sweep so users
+    # who haven't upgraded recently still get cleanup. Best-effort: if
+    # the install root isn't writable (system-managed install) we
+    # report 0 swept rather than failing the doctor.
+    typer.echo("\n# Self-upgrade backups")
+    install_root = _default_install_root()
+    typer.echo(f"  root:     {install_root}")
+    try:
+        removed = self_upgrade._cleanup_stale_backups(install_root)
+        if removed:
+            typer.echo(f"  swept:    {len(removed)} stale .old.<ts> files")
+        else:
+            typer.echo("  swept:    none")
+    except OSError as e:
+        typer.echo(f"  swept:    skipped ({e})")
 
     # --- Summary ----------------------------------------------------------
     typer.echo("\n# Summary")

--- a/src/wealthbox_tools/self_upgrade.py
+++ b/src/wealthbox_tools/self_upgrade.py
@@ -47,6 +47,7 @@ __all__ = [
     "UpgradeResult",
     "check",
     "apply",
+    "_cleanup_stale_backups",
 ]
 
 _RELEASES_LATEST_URL = (
@@ -54,6 +55,13 @@ _RELEASES_LATEST_URL = (
 )
 _CHECKSUMS_ASSET_NAME = "checksums.txt"
 _HTTP_TIMEOUT = httpx.Timeout(30.0)
+
+# Retention window for `<binary>.old.<unix_ts>` rollback breadcrumbs. After
+# 24 hours the user has either rolled back manually or the upgrade is
+# stable; the file is then disposable. Fixed by design (issue #39) — not
+# a parameter, so behavior is identical between `apply()` and `wbox
+# doctor` and there's no "policy" surface to diverge.
+_BACKUP_RETENTION_SECONDS = 24 * 3600
 
 
 # ---------------------------------------------------------------------------
@@ -396,6 +404,42 @@ def _schedule_deferred_swap(
     )
 
 
+def _cleanup_stale_backups(
+    install_root: Path, *, now: float | None = None
+) -> list[Path]:
+    """Remove ``<binary>.old.<unix_ts>`` files older than 24 h.
+
+    Sweeps the install directory for rollback breadcrumbs left by prior
+    successful :func:`apply` calls and unlinks any whose timestamp is
+    older than :data:`_BACKUP_RETENTION_SECONDS` relative to ``now``
+    (default: ``time.time()``). Returns the list of paths actually
+    removed so callers (``wbox doctor``) can report the count.
+
+    Defensive: a file whose trailing component cannot be parsed as an
+    integer is left alone — we never want a typo / unrelated
+    ``.old.something`` to be deleted by surprise.
+    """
+    install_root = Path(install_root)
+    cutoff = (now if now is not None else time.time()) - _BACKUP_RETENTION_SECONDS
+    pattern = f"{_binary_name()}.old.*"
+    removed: list[Path] = []
+    for path in install_root.glob(pattern):
+        suffix = path.name.rsplit(".", 1)[-1]
+        try:
+            ts = int(suffix)
+        except ValueError:
+            continue
+        if ts < cutoff:
+            try:
+                path.unlink(missing_ok=True)
+            except OSError:
+                # Stale handle / permission issue — best effort, the
+                # next sweep will retry.
+                continue
+            removed.append(path)
+    return removed
+
+
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
@@ -479,6 +523,16 @@ def apply(version: NewVersion, install_root: Path) -> UpgradeResult:
         except OSError:
             pass
         raise
+
+    # Sweep stale `.old.<ts>` breadcrumbs from prior successful upgrades
+    # (#39). Only runs on success — on failure the freshly-renamed
+    # backup IS the recovery path, and we don't want to risk the sweep
+    # catching it via a clock skew. Best-effort: any error here is
+    # swallowed because the upgrade itself succeeded.
+    try:
+        _cleanup_stale_backups(install_root)
+    except OSError:
+        pass
 
     return UpgradeResult(
         version=version.version,

--- a/tests/test_self_upgrade.py
+++ b/tests/test_self_upgrade.py
@@ -546,6 +546,90 @@ def test_read_and_clear_upgrade_status_handles_malformed_json(tmp_path: Path) ->
 
 
 # ---------------------------------------------------------------------------
+# _cleanup_stale_backups()
+# ---------------------------------------------------------------------------
+
+
+def test_cleanup_stale_backups_removes_old_keeps_recent(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Older-than-24h `.old.<ts>` is unlinked; recent breadcrumb is kept.
+
+    Defensively: a sibling file whose trailing component is non-numeric
+    must not be touched — we only sweep parseable timestamps.
+    """
+    monkeypatch.setattr(su, "_binary_name", lambda: "wbox")
+
+    frozen_now = 1_700_000_000
+    old_ts = frozen_now - (su._BACKUP_RETENTION_SECONDS + 60)  # >24h old
+    recent_ts = frozen_now - 60  # well within 24h
+
+    old_backup = tmp_path / f"wbox.old.{old_ts}"
+    recent_backup = tmp_path / f"wbox.old.{recent_ts}"
+    junk_backup = tmp_path / "wbox.old.notanumber"
+    old_backup.write_bytes(b"old")
+    recent_backup.write_bytes(b"recent")
+    junk_backup.write_bytes(b"junk")
+
+    removed = su._cleanup_stale_backups(tmp_path, now=frozen_now)
+
+    assert not old_backup.exists()
+    assert recent_backup.exists()
+    assert junk_backup.exists(), "non-numeric suffix must not be deleted"
+    assert old_backup in removed
+    assert recent_backup not in removed
+    assert junk_backup not in removed
+
+
+@respx.mock
+def test_apply_sweeps_stale_backups_on_success(tmp_path: Path, monkeypatch) -> None:
+    """A successful `apply()` sweeps prior `.old.<ts>` files older than 24h.
+
+    The freshly-created backup from this run (timestamp = frozen now) must
+    survive — it's the rollback path for THIS upgrade.
+    """
+    monkeypatch.setattr(su, "_binary_name", lambda: "wbox")
+    # Force the in-process Unix swap path so apply() actually performs the
+    # rename here; on a Windows runner the real `_is_windows()` would
+    # dispatch to `_schedule_deferred_swap` (PowerShell helper) and the
+    # cleanup-after-rename behavior we're asserting wouldn't be observable.
+    monkeypatch.setattr(su, "_is_windows", lambda: False)
+
+    install_root = tmp_path
+    current = install_root / "wbox"
+    current.write_bytes(b"old-binary-bytes")
+
+    # Pre-seed a very old `.old.<ts>` from a previous upgrade.
+    frozen_now = 1_700_000_000
+    stale_ts = frozen_now - (su._BACKUP_RETENTION_SECONDS + 3600)
+    stale_backup = install_root / f"wbox.old.{stale_ts}"
+    stale_backup.write_bytes(b"ancient-backup")
+
+    new_bytes = b"new-binary-bytes-v9-9-9"
+    digest = hashlib.sha256(new_bytes).hexdigest()
+    binary_url = "https://example.com/wbox-linux-x64"
+    respx.get(binary_url).mock(return_value=httpx.Response(200, content=new_bytes))
+
+    monkeypatch.setattr(su.time, "time", lambda: frozen_now)
+
+    candidate = su.NewVersion(
+        version="9.9.9",
+        binary_url=binary_url,
+        sha256=digest,
+        asset_name="wbox-linux-x64",
+    )
+
+    su.apply(candidate, install_root=install_root)
+
+    # Stale breadcrumb is gone…
+    assert not stale_backup.exists(), "apply() should have swept the stale backup"
+    # …but the freshly-created backup from THIS run survives.
+    fresh_backup = install_root / f"wbox.old.{frozen_now}"
+    assert fresh_backup.exists()
+    assert fresh_backup.read_bytes() == b"old-binary-bytes"
+
+
+# ---------------------------------------------------------------------------
 # CLI smoke
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Adds a stale-backup sweep so `<binary>.old.<unix_ts>` rollback breadcrumbs older than 24 h don't accumulate in the install root.

- New helper `self_upgrade._cleanup_stale_backups(install_root, *, now=None)` next to the rename code that creates these files. Fixed 24 h threshold (`_BACKUP_RETENTION_SECONDS = 24*3600`) — not configurable.
- `apply()` calls the helper after a successful rename pair (NOT in the `except` branch — failed upgrades still need the breadcrumb).
- `wbox doctor` runs the same sweep in a new "Self-upgrade backups" section between firm data and Summary, reporting `swept: N stale .old.<ts> files` (or `none`). Install root is resolved via `cli.self_cmd._default_install_root` so all CLI surfaces agree.
- Defensive parse: a non-numeric `.old.<suffix>` is left alone.

Closes #39.

Touches `self_upgrade.py` and `tests/test_self_upgrade.py` which PR #68 also modifies; rebase will be needed if #68 lands first.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `pytest -q` — 339 passed, 1 skipped
- [x] New: `test_cleanup_stale_backups_removes_old_keeps_recent` — old removed, recent + non-numeric suffix kept, return value contains old.
- [x] New: `test_apply_sweeps_stale_backups_on_success` — pre-seeded ancient `.old.<ts>` swept, freshly-created backup from this run survives.