### PR TITLE
feat: skills-upgrade subprocess wiring after self-upgrade (#40)

### DIFF
--- a/src/wealthbox_tools/cli/main.py
+++ b/src/wealthbox_tools/cli/main.py
@@ -37,15 +37,29 @@ def _check_pending_upgrade_status() -> None:
     and unlink it. Never raises; a corrupt status file would otherwise nag
     the user every invocation.
 
+    If a ``wbox.skills_upgrade.pending`` marker exists (#40) and the deferred
+    swap succeeded, also invoke ``<new binary> skills upgrade`` so the skill
+    template tracks the new binary. The marker is always cleared, even when
+    the upgrade failed, so a stale marker doesn't drive future invocations.
+
     Resolves ``_default_install_root`` through the module reference so tests
     can monkeypatch it on :mod:`cli.self_cmd` and have the change take
     effect here.
     """
-    status = self_upgrade._read_and_clear_upgrade_status(self_cmd._default_install_root())
+    install_root = self_cmd._default_install_root()
+    status = self_upgrade._read_and_clear_upgrade_status(install_root)
+    pending_marker = install_root / self_upgrade._SKILLS_UPGRADE_PENDING_FILENAME
+    marker_existed = pending_marker.exists()
+    if marker_existed:
+        try:
+            pending_marker.unlink(missing_ok=True)
+        except OSError:
+            pass
     if status is None:
         return
     version = status.get("version") or "?"
-    if status.get("result") == "ok":
+    swap_ok = status.get("result") == "ok"
+    if swap_ok:
         typer.echo(f"wbox: upgrade to v{version} completed.", err=True)
     else:
         reason = status.get("reason") or "unknown error"
@@ -53,6 +67,16 @@ def _check_pending_upgrade_status() -> None:
             f"wbox: upgrade to v{version} failed ({reason}). Old binary still in place.",
             err=True,
         )
+
+    if swap_ok and marker_existed:
+        binary_path = install_root / self_upgrade._binary_name()
+        rc = self_upgrade._invoke_skills_upgrade(binary_path)
+        if rc != 0:
+            typer.echo(
+                f"wbox: `wbox skills upgrade` exited with code {rc}; "
+                "re-run manually to refresh the skill template.",
+                err=True,
+            )
 
 app = typer.Typer(context_settings={"help_option_names": ["-h", "--help"]}, 
     name="wbox",

--- a/src/wealthbox_tools/cli/main.py
+++ b/src/wealthbox_tools/cli/main.py
@@ -48,6 +48,13 @@ def _check_pending_upgrade_status() -> None:
     """
     install_root = self_cmd._default_install_root()
     status = self_upgrade._read_and_clear_upgrade_status(install_root)
+    if status is None:
+        # No status yet (deferred-swap helper hasn't completed, or no upgrade
+        # in flight). Leave the skills-upgrade marker in place — clearing it
+        # now would lose the signal if the user relaunches before the helper
+        # writes its status file. Next launch will see the status and the
+        # marker together.
+        return
     pending_marker = install_root / self_upgrade._SKILLS_UPGRADE_PENDING_FILENAME
     marker_existed = pending_marker.exists()
     if marker_existed:
@@ -55,8 +62,6 @@ def _check_pending_upgrade_status() -> None:
             pending_marker.unlink(missing_ok=True)
         except OSError:
             pass
-    if status is None:
-        return
     version = status.get("version") or "?"
     swap_ok = status.get("result") == "ok"
     if swap_ok:

--- a/src/wealthbox_tools/self_upgrade.py
+++ b/src/wealthbox_tools/self_upgrade.py
@@ -245,6 +245,39 @@ def _schedule_swap(
 
 _STATUS_FILENAME = "wbox.upgrade.status"
 
+# Marker file written by `apply()` on Windows after scheduling the deferred
+# swap. The actual `wbox skills upgrade` subprocess can't run from the parent
+# (the new binary isn't on disk yet — the helper renames it after parent
+# exit), so the marker tells :func:`_check_pending_upgrade_status` to fire
+# the subprocess once it confirms the deferred swap succeeded. On Unix the
+# swap is synchronous, so :func:`apply` invokes the subprocess inline and
+# this marker is never written.
+_SKILLS_UPGRADE_PENDING_FILENAME = "wbox.skills_upgrade.pending"
+
+
+def _invoke_skills_upgrade(binary_path: Path) -> int:
+    """Run ``<binary_path> skills upgrade`` and stream output to the terminal.
+
+    Returns the subprocess exit code. Output is intentionally NOT captured —
+    we want the user to see template-refresh progress live. Errors during
+    spawn (e.g., the binary disappeared between rename and exec) are caught
+    and returned as a synthetic non-zero so the caller can warn without
+    rolling back the binary swap; the binary is already in place and the
+    user can re-run ``wbox skills upgrade`` manually.
+
+    Indirected (rather than inlined into :func:`apply`) so tests can
+    monkeypatch a single seam without simulating the full subprocess
+    machinery.
+    """
+    try:
+        completed = subprocess.run(
+            [str(binary_path), "skills", "upgrade"],
+            check=False,
+        )
+        return completed.returncode
+    except OSError:
+        return 1
+
 
 def _read_and_clear_upgrade_status(install_root: Path) -> dict | None:
     """Read + clear the upgrade status file written by the Windows helper.
@@ -523,6 +556,33 @@ def apply(version: NewVersion, install_root: Path) -> UpgradeResult:
         except OSError:
             pass
         raise
+
+    # Refresh the agent skill template in lockstep with the new binary (#40).
+    # On Unix the swap is synchronous, so we invoke `<new wbox> skills upgrade`
+    # right here. On Windows the swap is deferred to a child process that runs
+    # after the parent exits; we drop a marker file and let the next-launch
+    # callback fire the subprocess once it has confirmed the swap succeeded.
+    # A non-zero exit is a warning, never a rollback — the binary is already
+    # in place and the user can re-run `wbox skills upgrade` manually.
+    if _is_windows():
+        try:
+            (install_root / _SKILLS_UPGRADE_PENDING_FILENAME).write_text("")
+        except OSError:
+            pass
+    else:
+        try:
+            rc = _invoke_skills_upgrade(current_path)
+        except Exception:
+            rc = 1
+        if rc != 0:
+            # Surface to the user; the parent process is still alive on Unix
+            # so this lands on the active terminal.
+            print(
+                f"warning: `wbox skills upgrade` exited with code {rc}; "
+                "the binary swap is intact. Re-run manually to refresh the "
+                "skill template.",
+                file=sys.stderr,
+            )
 
     # Sweep stale `.old.<ts>` breadcrumbs from prior successful upgrades
     # (#39). Only runs on success — on failure the freshly-renamed

--- a/tests/test_self_upgrade.py
+++ b/tests/test_self_upgrade.py
@@ -891,3 +891,246 @@ def test_self_upgrade_cli_no_op_when_up_to_date(runner) -> None:
 
     result = runner.invoke(app, ["self", "upgrade"])
     assert result.exit_code == 0, result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Skills-upgrade subprocess wiring (#40)
+#
+# After a successful binary swap, `wbox skills upgrade` must run so the skill
+# template is refreshed in lockstep with the new binary. On Unix the swap is
+# synchronous so the subprocess fires inside `apply()`. On Windows the swap is
+# deferred to a child process that runs after the parent exits, so `apply()`
+# writes a marker file and the actual subprocess fires from the next-launch
+# callback once the deferred swap is confirmed successful.
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+def test_apply_invokes_skills_upgrade_on_unix(tmp_path: Path, monkeypatch) -> None:
+    """After the synchronous Unix swap, apply() must invoke `wbox skills upgrade`.
+
+    The subprocess is invoked using the just-installed binary so the freshly
+    written executable does the template refresh — keeping the binary and skill
+    template in lockstep on disk.
+    """
+    monkeypatch.setattr(su, "_binary_name", lambda: "wbox")
+    monkeypatch.setattr(su, "_is_windows", lambda: False)
+
+    install_root = tmp_path
+    current = install_root / "wbox"
+    current.write_bytes(b"old-binary-bytes")
+
+    new_bytes = b"new-binary-bytes-v9-9-9"
+    digest = hashlib.sha256(new_bytes).hexdigest()
+    binary_url = "https://example.com/wbox-linux-x64"
+    respx.get(binary_url).mock(return_value=httpx.Response(200, content=new_bytes))
+
+    invocations: list[tuple[Path, ...]] = []
+
+    def fake_invoke(binary_path: Path) -> int:
+        invocations.append((binary_path,))
+        return 0
+
+    monkeypatch.setattr(su, "_invoke_skills_upgrade", fake_invoke)
+
+    candidate = su.NewVersion(
+        version="9.9.9",
+        binary_url=binary_url,
+        sha256=digest,
+        asset_name="wbox-linux-x64",
+    )
+
+    su.apply(candidate, install_root=install_root)
+
+    assert len(invocations) == 1, (
+        f"expected exactly one skills-upgrade invocation, got {invocations}"
+    )
+    assert invocations[0][0] == current
+
+
+@respx.mock
+def test_apply_unix_does_not_rollback_when_skills_upgrade_fails(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    """Skills-upgrade subprocess failure must NOT undo the binary swap.
+
+    The binary is already in place; the user can re-run `wbox skills upgrade`
+    manually. Tearing down the swap on a skills-upgrade hiccup would be a
+    cure-worse-than-the-disease for what is essentially a template refresh.
+    """
+    monkeypatch.setattr(su, "_binary_name", lambda: "wbox")
+    monkeypatch.setattr(su, "_is_windows", lambda: False)
+
+    install_root = tmp_path
+    current = install_root / "wbox"
+    current.write_bytes(b"old-binary-bytes")
+
+    new_bytes = b"new-binary-bytes-v9-9-9"
+    digest = hashlib.sha256(new_bytes).hexdigest()
+    binary_url = "https://example.com/wbox-linux-x64"
+    respx.get(binary_url).mock(return_value=httpx.Response(200, content=new_bytes))
+
+    monkeypatch.setattr(su, "_invoke_skills_upgrade", lambda binary_path: 1)
+
+    candidate = su.NewVersion(
+        version="9.9.9",
+        binary_url=binary_url,
+        sha256=digest,
+        asset_name="wbox-linux-x64",
+    )
+
+    # Must not raise — non-zero exit is a warning, not a failure.
+    result = su.apply(candidate, install_root=install_root)
+
+    # Binary swap is intact: new bytes in place, old bytes preserved as backup.
+    assert current.read_bytes() == new_bytes
+    assert result.backup_path.exists()
+    assert result.backup_path.read_bytes() == b"old-binary-bytes"
+
+
+@respx.mock
+def test_apply_windows_writes_skills_upgrade_pending_marker(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """On Windows, apply() defers the swap and writes a skills-upgrade marker.
+
+    The actual `wbox skills upgrade` subprocess can't run from the parent —
+    the swap hasn't happened yet. Instead the marker tells the next-launch
+    callback to fire the subprocess once the deferred swap is confirmed.
+    """
+    monkeypatch.setattr(su, "_binary_name", lambda: "wbox.exe")
+    monkeypatch.setattr(su, "_is_windows", lambda: True)
+    monkeypatch.setattr(su, "_schedule_deferred_swap", lambda *a, **kw: None)
+
+    install_root = tmp_path
+    current = install_root / "wbox.exe"
+    current.write_bytes(b"old-bytes")
+
+    new_bytes = b"new-windows-bytes"
+    digest = hashlib.sha256(new_bytes).hexdigest()
+    binary_url = "https://example.com/wbox-windows-x64.exe"
+    respx.get(binary_url).mock(return_value=httpx.Response(200, content=new_bytes))
+
+    candidate = su.NewVersion(
+        version="9.9.9",
+        binary_url=binary_url,
+        sha256=digest,
+        asset_name="wbox-windows-x64.exe",
+    )
+
+    su.apply(candidate, install_root=install_root)
+
+    pending_marker = install_root / su._SKILLS_UPGRADE_PENDING_FILENAME
+    assert pending_marker.exists(), (
+        f"apply() should have written the skills-upgrade pending marker on Windows; "
+        f"contents of install_root: {list(install_root.iterdir())}"
+    )
+
+
+def test_main_callback_runs_skills_upgrade_on_successful_deferred_swap(
+    runner, tmp_path, monkeypatch
+) -> None:
+    """When the deferred swap succeeds AND a skills-upgrade marker is present,
+    the next-launch callback fires `wbox skills upgrade` and clears the marker.
+    """
+    from wealthbox_tools.cli import self_cmd
+
+    monkeypatch.setattr(self_cmd, "_default_install_root", lambda: tmp_path)
+    monkeypatch.setattr(su, "_binary_name", lambda: "wbox.exe")
+
+    status_path = tmp_path / "wbox.upgrade.status"
+    status_path.write_text(
+        json.dumps({"result": "ok", "version": "9.9.9", "reason": None, "ts": 1700000000})
+    )
+    pending_marker = tmp_path / su._SKILLS_UPGRADE_PENDING_FILENAME
+    pending_marker.write_text("")
+
+    invocations: list[Path] = []
+
+    def fake_invoke(binary_path: Path) -> int:
+        invocations.append(binary_path)
+        return 0
+
+    monkeypatch.setattr(su, "_invoke_skills_upgrade", fake_invoke)
+
+    result = runner.invoke(app, ["--version"])
+
+    assert result.exit_code == 0, result.stdout
+    assert len(invocations) == 1
+    assert invocations[0] == tmp_path / "wbox.exe"
+    assert not pending_marker.exists(), (
+        "the skills-upgrade pending marker must be cleared after running"
+    )
+
+
+def test_main_callback_skips_skills_upgrade_when_swap_failed(
+    runner, tmp_path, monkeypatch
+) -> None:
+    """If the deferred swap failed, skills upgrade is NOT run.
+
+    The marker is still cleared so it doesn't leak across runs — a future
+    successful `wbox self upgrade` will write a fresh marker.
+    """
+    from wealthbox_tools.cli import self_cmd
+
+    monkeypatch.setattr(self_cmd, "_default_install_root", lambda: tmp_path)
+
+    status_path = tmp_path / "wbox.upgrade.status"
+    status_path.write_text(
+        json.dumps(
+            {
+                "result": "failed",
+                "version": "9.9.9",
+                "reason": "timeout waiting for parent exit",
+                "ts": 1700000000,
+            }
+        )
+    )
+    pending_marker = tmp_path / su._SKILLS_UPGRADE_PENDING_FILENAME
+    pending_marker.write_text("")
+
+    invocations: list[Path] = []
+
+    def fake_invoke(binary_path: Path) -> int:
+        invocations.append(binary_path)
+        return 0
+
+    monkeypatch.setattr(su, "_invoke_skills_upgrade", fake_invoke)
+
+    result = runner.invoke(app, ["--version"])
+
+    assert result.exit_code == 0, result.stdout
+    assert invocations == [], "skills upgrade must not run when the deferred swap failed"
+    assert not pending_marker.exists(), (
+        "marker must be cleared even when skill upgrade is skipped"
+    )
+
+
+def test_invoke_skills_upgrade_calls_subprocess_with_binary_path(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """`_invoke_skills_upgrade` runs `<binary> skills upgrade` and streams output.
+
+    Output is streamed (not captured) so the user sees live progress; exit code
+    is returned to the caller for warning-vs-rollback decisions.
+    """
+    binary_path = tmp_path / "wbox"
+    binary_path.write_bytes(b"")
+
+    captured: dict = {}
+
+    class FakeCompleted:
+        returncode = 0
+
+    def fake_run(args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return FakeCompleted()
+
+    monkeypatch.setattr(su.subprocess, "run", fake_run)
+
+    rc = su._invoke_skills_upgrade(binary_path)
+
+    assert rc == 0
+    assert captured["args"][0] == str(binary_path)
+    assert captured["args"][1:] == ["skills", "upgrade"]


### PR DESCRIPTION
## Summary
- After a successful binary swap, `apply()` runs `wbox skills upgrade` so the skill template stays in lockstep with the new binary. Output is streamed to the user's terminal.
- A non-zero exit from the subprocess is surfaced as a warning but does **not** roll back the swap — the binary is already in place and the user can re-run `wbox skills upgrade` manually.

## Windows approach: option (b) — deferred via marker file
On Windows the swap itself is deferred (PR #67) to a PowerShell helper that runs after the parent exits, so `apply()` cannot fire the subprocess synchronously — the new binary isn't on disk yet. Picking between the two options laid out in the issue:

- **(a)** Bake the skill upgrade into the PowerShell helper.
- **(b)** Drop a marker file in `apply()` and run the subprocess from `_check_pending_upgrade_status()` on the next `wbox` launch (only when the deferred swap was reported `ok`).

I went with **(b)**: it keeps the subprocess invocation logic in Python (one helper, `_invoke_skills_upgrade`), reuses the existing next-launch callback that already reads the upgrade status file, and avoids embedding more behavior into the inline PowerShell script. The marker (`wbox.skills_upgrade.pending`) is written next to the binary in `apply()` and unconditionally cleared by the callback so it can never go stale.

## Test plan
- [x] `tests/test_self_upgrade.py::test_apply_invokes_skills_upgrade_on_unix` — Unix path fires the subprocess against the just-installed binary.
- [x] `tests/test_self_upgrade.py::test_apply_unix_does_not_rollback_when_skills_upgrade_fails` — non-zero exit leaves the binary swap intact.
- [x] `tests/test_self_upgrade.py::test_apply_windows_writes_skills_upgrade_pending_marker` — Windows path writes the marker.
- [x] `tests/test_self_upgrade.py::test_main_callback_runs_skills_upgrade_on_successful_deferred_swap` — next-launch callback fires the subprocess and clears the marker when the swap was `ok`.
- [x] `tests/test_self_upgrade.py::test_main_callback_skips_skills_upgrade_when_swap_failed` — failed swap does **not** run the subprocess but still clears the marker.
- [x] `tests/test_self_upgrade.py::test_invoke_skills_upgrade_calls_subprocess_with_binary_path` — the helper invokes `<binary> skills upgrade`.
- [x] `PYTHONPATH=src pytest -q tests/test_self_upgrade.py` → 31 passed, 1 skipped.
- [x] Full suite → 355 passed, 1 skipped.
- [x] `ruff check src/ tests/` → all checks passed.

Closes #40

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>