### PR TITLE
feat: post-import provenance + 90-day doctor freshness warning (#48)

### DIFF
--- a/src/wealthbox_tools/cli/_skill_bootstrap.py
+++ b/src/wealthbox_tools/cli/_skill_bootstrap.py
@@ -206,6 +206,18 @@ def write_firm_meta(data: dict[str, Any]) -> None:
     p.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
 
 
+#: Top-level firm-meta keys that must survive a regenerate (`wbox skills
+#: refresh` / re-bootstrap). These are user-state, not derived data:
+#: ``onboarded_at`` is set by the agent after qualitative Q&A; the
+#: ``last_imported_*`` pair is set by `wbox firm import` (#48) and powers
+#: the doctor's 90-day staleness warning.
+_PRESERVED_FIRM_META_KEYS: tuple[str, ...] = (
+    "onboarded_at",
+    "last_imported_from",
+    "last_imported_at",
+)
+
+
 def update_firm_meta(
     *,
     identity: dict[str, Any],
@@ -214,7 +226,9 @@ def update_firm_meta(
 ) -> None:
     """Write firm identity + generated-file timestamps to canonical firm meta.
 
-    Preserves `onboarded_at` (set by the agent via `wbox skills mark-onboarded`).
+    Preserves user-state keys (``onboarded_at`` from `wbox skills mark-onboarded`,
+    ``last_imported_from`` / ``last_imported_at`` from `wbox firm import`) so a
+    regenerate doesn't drop them.
     """
     now = datetime.now(timezone.utc).isoformat()
     existing = read_firm_meta()
@@ -223,9 +237,9 @@ def update_firm_meta(
         "cli_version": cli_version,
         "files": {name: now for name in generated_files},
     }
-    onboarded_at = existing.get("onboarded_at")
-    if onboarded_at:
-        new_meta["onboarded_at"] = onboarded_at
+    for key in _PRESERVED_FIRM_META_KEYS:
+        if existing.get(key):
+            new_meta[key] = existing[key]
     write_firm_meta(new_meta)
 
 

--- a/src/wealthbox_tools/cli/doctor.py
+++ b/src/wealthbox_tools/cli/doctor.py
@@ -9,7 +9,7 @@ import os
 import platform as _platform_module
 import shutil
 import sys
-from datetime import datetime
+from datetime import datetime, timezone
 from importlib.metadata import version as _pkg_version
 
 import typer
@@ -161,6 +161,40 @@ def run_doctor(token: str | None = None) -> int:
                     typer.echo(f"  oldest:   {oldest}")
                 except (ValueError, TypeError):
                     pass
+
+        # Firm-import freshness (#48). Soft check: warn if the firm dir
+        # was last imported >90 days ago and nudge the user to ask their
+        # admin for a fresh export. Absent fields (never-imported case)
+        # produce no warning — same shape as the release-age soft check
+        # above. Same defensive parse: a malformed timestamp is treated
+        # as "no signal" rather than a hard fail.
+        last_imported_at = firm_meta.get("last_imported_at")
+        last_imported_from = firm_meta.get("last_imported_from")
+        if isinstance(last_imported_at, str) and last_imported_at:
+            try:
+                imported_dt = datetime.fromisoformat(
+                    last_imported_at.replace("Z", "+00:00")
+                )
+            except ValueError:
+                imported_dt = None
+            if imported_dt is not None:
+                if imported_dt.tzinfo is None:
+                    imported_dt = imported_dt.replace(tzinfo=timezone.utc)
+                age_days = (datetime.now(timezone.utc) - imported_dt).days
+                typer.echo(
+                    f"  imported: {last_imported_at} ({age_days}d ago)"
+                    + (f" from {last_imported_from}" if last_imported_from else "")
+                )
+                if age_days > 90:
+                    typer.echo(
+                        "  warning:  firm data is more than 90 days old - "
+                        "ask your admin for the latest export and "
+                        "re-run 'wbox firm import'"
+                    )
+                    issues.append(
+                        f"firm data was last imported {age_days} days ago - "
+                        "ask your admin for the latest export"
+                    )
 
     # --- Release age (30-days-behind warning, #41) -----------------------
     # Soft check: a network error here yields a "could not check for

--- a/src/wealthbox_tools/cli/firm.py
+++ b/src/wealthbox_tools/cli/firm.py
@@ -81,7 +81,7 @@ def import_firm(
         )
 
     try:
-        result = _apply(plan, dest, ApplyMode.OVERWRITE)
+        result = _apply(plan, dest, ApplyMode.OVERWRITE, source=str(path))
     except ArchiveError as exc:
         raise typer.BadParameter(str(exc)) from exc
     typer.echo(f"Wrote {len(result.written)} file(s) to {dest}.", err=True)

--- a/src/wealthbox_tools/firm/archive.py
+++ b/src/wealthbox_tools/firm/archive.py
@@ -256,6 +256,9 @@ def apply(
     plan: ImportPlan,
     firm_dir: Path,
     mode: ApplyMode = ApplyMode.OVERWRITE,
+    *,
+    source: str | None = None,
+    now: datetime | None = None,
 ) -> ApplyResult:
     """Write the files from ``plan`` into ``firm_dir`` according to ``mode``.
 
@@ -266,6 +269,13 @@ def apply(
 
     ``MERGE`` and ``ABORT_ON_CONFLICT`` are not implemented in this slice
     and raise :class:`ArchiveError`. Issue #46 will fill them in.
+
+    When ``source`` is provided, ``last_imported_from=source`` and
+    ``last_imported_at=<now ISO>`` are stamped into ``_meta.json`` (#48).
+    These provenance fields power the doctor's 90-day-stale warning. The
+    write is read-modify-write into the existing meta — generated keys
+    (identity, cli_version, files) survive untouched, just like a normal
+    ``_meta.json`` merge from the archive.
     """
     if mode is not ApplyMode.OVERWRITE:
         raise ArchiveError(
@@ -288,7 +298,46 @@ def apply(
             content = _merge_meta_bytes(target, content)
         target.write_bytes(content)
         written.append(name)
+
+    # Post-import provenance (#48). Stamped after the file loop so the
+    # write happens whether or not the archive itself carried _meta.json
+    # — a stripped-down archive (no policy keys to merge) still gets
+    # provenance, and an archive that did include _meta.json gets the
+    # provenance keys merged on top of the freshly-written meta.
+    if source is not None:
+        timestamp = (now if now is not None else datetime.now(timezone.utc)).isoformat()
+        meta_target = firm_dir / META_FILENAME
+        provenance = {
+            "last_imported_from": source,
+            "last_imported_at": timestamp,
+        }
+        meta_target.write_bytes(_merge_provenance_bytes(meta_target, provenance))
+        if META_FILENAME not in written:
+            written.append(META_FILENAME)
+
     return ApplyResult(written=tuple(written))
+
+
+def _merge_provenance_bytes(target: Path, provenance: dict[str, Any]) -> bytes:
+    """Merge ``last_imported_from`` / ``last_imported_at`` into ``_meta.json``.
+
+    Read-modify-write the destination meta so the new provenance keys land
+    on top of whatever's already there. If the file is missing or
+    malformed, fall back to writing the provenance subset alone — the
+    doctor's freshness warning treats a missing-file case the same as a
+    never-imported one, so a stale-but-unparseable meta still gets
+    healed by the next ``apply``.
+    """
+    existing_obj: dict[str, Any] = {}
+    if target.exists():
+        try:
+            loaded = json.loads(target.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            loaded = None
+        if isinstance(loaded, dict):
+            existing_obj = loaded
+    merged = {**existing_obj, **provenance}
+    return (json.dumps(merged, indent=2) + "\n").encode("utf-8")
 
 
 def _merge_meta_bytes(target: Path, incoming: bytes) -> bytes:

--- a/tests/test_doctor_cli.py
+++ b/tests/test_doctor_cli.py
@@ -263,3 +263,105 @@ def test_doctor_soft_warning_on_network_error(runner, tmp_path, monkeypatch):
     assert "could not check for updates" in out
     # The soft warning must NOT appear in the issues list.
     assert "wbox self upgrade" not in out
+
+
+# ---------------------------------------------------------------------------
+# Firm-import freshness: 90-days-stale warning (#48)
+# ---------------------------------------------------------------------------
+
+
+def _seed_firm_meta(tmp_path, extra: dict) -> None:
+    """Write a fully-bootstrapped firm meta plus ``extra`` overrides.
+
+    The doctor's firm-data section requires identity + onboarded_at to
+    reach the freshness branch, so the helper bakes in a healthy baseline
+    and lets each test add ``last_imported_*`` (or omit them) on top.
+    """
+    from wealthbox_tools.cli._skill_paths import firm_meta_path
+    base = {
+        "identity": {"id": 1, "name": "Firm", "user_id": 1, "user_name": "Adv"},
+        "cli_version": "1.2.0",
+        "files": {"categories.md": "2026-05-01T00:00:00+00:00"},
+        "onboarded_at": "2026-05-02T00:00:00+00:00",
+    }
+    base.update(extra)
+    p = firm_meta_path()
+    p.parent.mkdir(parents=True, exist_ok=True)
+    import json
+    p.write_text(json.dumps(base, indent=2))
+
+
+@respx.mock
+def test_doctor_warns_when_firm_data_imported_more_than_90_days_ago(
+    runner, tmp_path, monkeypatch
+):
+    """``last_imported_at`` >90 days old → doctor prints the freshness warning."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    monkeypatch.chdir(tmp_path)
+    _mock_me()
+
+    stale = (datetime.now(timezone.utc) - timedelta(days=120)).isoformat()
+    _seed_firm_meta(
+        tmp_path,
+        {
+            "last_imported_from": "/path/to/firm-export.zip",
+            "last_imported_at": stale,
+        },
+    )
+
+    result = runner.invoke(app, ["doctor"])
+    out = result.stdout
+    assert "# Firm data" in out
+    assert "90 days" in out or "ask your admin" in out
+    # The warning must surface in the summary issues list, not exit non-zero.
+    assert "issue(s) found" in out
+
+
+@respx.mock
+def test_doctor_no_freshness_warning_when_never_imported(
+    runner, tmp_path, monkeypatch
+):
+    """A firm meta without ``last_imported_*`` (never imported) produces
+    no freshness warning — bootstrapped firms that haven't pulled an
+    archive yet are a perfectly normal state."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    monkeypatch.chdir(tmp_path)
+    _mock_me()
+
+    _seed_firm_meta(tmp_path, {})  # baseline only — no last_imported_*
+
+    result = runner.invoke(app, ["doctor"])
+    out = result.stdout
+    # Freshness warning must NOT appear.
+    assert "ask your admin" not in out
+    assert "more than 90 days" not in out
+
+
+@respx.mock
+def test_doctor_no_freshness_warning_when_imported_recently(
+    runner, tmp_path, monkeypatch
+):
+    """A recent ``last_imported_at`` (well under 90 days) records the
+    breadcrumb but does not warn."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    monkeypatch.chdir(tmp_path)
+    _mock_me()
+
+    fresh = (datetime.now(timezone.utc) - timedelta(days=10)).isoformat()
+    _seed_firm_meta(
+        tmp_path,
+        {
+            "last_imported_from": "/path/to/firm-export.zip",
+            "last_imported_at": fresh,
+        },
+    )
+
+    result = runner.invoke(app, ["doctor"])
+    out = result.stdout
+    # Breadcrumb still rendered for transparency...
+    assert "imported:" in out
+    # ...but no warning fired.
+    assert "ask your admin" not in out

--- a/tests/test_firm_import.py
+++ b/tests/test_firm_import.py
@@ -482,3 +482,98 @@ def test_firm_import_cli_surfaces_clear_error_on_bad_format_version(
     combined = (result.stdout or "") + (result.stderr or "")
     assert "format_version" in combined
     assert "Traceback" not in combined
+
+
+# --------------------------------------------------------------------------- #
+# Post-import provenance (#48)                                                #
+# --------------------------------------------------------------------------- #
+
+
+def test_apply_writes_last_imported_provenance(tmp_path: Path) -> None:
+    """A successful ``apply`` stamps ``last_imported_from`` /
+    ``last_imported_at`` into the destination's ``_meta.json`` so the
+    doctor can warn when the data goes stale (#48)."""
+    src = tmp_path / "src"
+    _populated_firm_dir(src)
+    archive = tmp_path / "firm.zip"
+    archive.write_bytes(pack(src, now=_PINNED_NOW))
+
+    dst = tmp_path / "dst"
+    dst.mkdir()
+    plan = unpack(archive)
+
+    pinned = datetime(2026, 5, 9, 12, 0, 0, tzinfo=timezone.utc)
+    apply(plan, dst, ApplyMode.OVERWRITE, source=str(archive), now=pinned)
+
+    meta = json.loads((dst / "_meta.json").read_text(encoding="utf-8"))
+    assert meta["last_imported_from"] == str(archive)
+    assert meta["last_imported_at"] == pinned.isoformat()
+    # Policy keys carried in the archive still merge through.
+    assert meta["onboarded_at"] == "2024-02-15T12:34:56+00:00"
+
+
+def test_apply_provenance_preserves_existing_generated_keys(tmp_path: Path) -> None:
+    """Provenance stamping must not clobber identity / cli_version / files
+    on the destination — those are generated keys that ``wbox doctor`` and
+    the bootstrap machinery rely on."""
+    src = tmp_path / "src"
+    _populated_firm_dir(src)
+    archive = tmp_path / "firm.zip"
+    archive.write_bytes(pack(src, now=_PINNED_NOW))
+
+    dst = tmp_path / "dst"
+    dst.mkdir()
+    pre_existing = {
+        "identity": {"id": 42, "name": "Local Firm", "user_id": 7},
+        "cli_version": "1.6.0",
+        "files": {"categories.md": "2026-04-01T00:00:00+00:00"},
+        "onboarded_at": "2025-01-01T00:00:00+00:00",
+    }
+    (dst / "_meta.json").write_text(json.dumps(pre_existing, indent=2), encoding="utf-8")
+
+    plan = unpack(archive)
+    pinned = datetime(2026, 5, 9, 12, 0, 0, tzinfo=timezone.utc)
+    apply(plan, dst, ApplyMode.OVERWRITE, source="https://firm.example/export.zip", now=pinned)
+
+    meta = json.loads((dst / "_meta.json").read_text(encoding="utf-8"))
+    assert meta["identity"] == pre_existing["identity"]
+    assert meta["cli_version"] == pre_existing["cli_version"]
+    assert meta["files"] == pre_existing["files"]
+    assert meta["last_imported_from"] == "https://firm.example/export.zip"
+    assert meta["last_imported_at"] == pinned.isoformat()
+
+
+def test_apply_without_source_does_not_write_provenance(tmp_path: Path) -> None:
+    """Library callers that omit ``source`` (e.g. internal tests) get the
+    pre-#48 behavior — no provenance is stamped."""
+    src = tmp_path / "src"
+    _populated_firm_dir(src)
+    archive = tmp_path / "firm.zip"
+    archive.write_bytes(pack(src, now=_PINNED_NOW))
+
+    dst = tmp_path / "dst"
+    dst.mkdir()
+    plan = unpack(archive)
+    apply(plan, dst, ApplyMode.OVERWRITE)  # no source kwarg
+
+    meta = json.loads((dst / "_meta.json").read_text(encoding="utf-8"))
+    assert "last_imported_from" not in meta
+    assert "last_imported_at" not in meta
+
+
+def test_firm_import_cli_stamps_provenance(runner, tmp_path: Path) -> None:
+    """The CLI passes the archive path through to ``apply`` so the user's
+    firm dir picks up the freshness fields after a real ``wbox firm import``."""
+    from wealthbox_tools.cli._skill_paths import firm_meta_path
+
+    src = tmp_path / "src"
+    _populated_firm_dir(src)
+    archive = tmp_path / "firm.zip"
+    archive.write_bytes(pack(src, now=_PINNED_NOW))
+
+    result = runner.invoke(app, ["firm", "import", str(archive), "--yes"])
+    assert result.exit_code == 0, result.stdout
+
+    meta = json.loads(firm_meta_path().read_text(encoding="utf-8"))
+    assert meta["last_imported_from"] == str(archive)
+    assert isinstance(meta.get("last_imported_at"), str) and meta["last_imported_at"]

--- a/tests/test_skill_bootstrap_render.py
+++ b/tests/test_skill_bootstrap_render.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+
 from wealthbox_tools.cli._skill_bootstrap import (
     render_categories_md,
     render_custom_fields_md,
@@ -151,6 +153,40 @@ def test_update_firm_meta_writes_to_canonical_path():
     for ts in meta["files"].values():
         assert "T" in ts  # ISO 8601
     assert firm_meta_path().exists()
+
+
+def test_update_firm_meta_preserves_import_provenance():
+    """Re-bootstrap (e.g., `wbox skills refresh`) must not drop the
+    `last_imported_*` provenance fields written by `wbox firm import`,
+    or the doctor's 90-day staleness warning silently breaks for any
+    user who refreshes after importing.
+    """
+    # Seed an existing firm meta with both onboarded_at and import provenance.
+    update_firm_meta(
+        identity={"id": 1, "name": "Firm"},
+        cli_version="1.1.0",
+        generated_files=["categories.md"],
+    )
+    seeded = read_firm_meta()
+    seeded["onboarded_at"] = "2026-01-01T00:00:00+00:00"
+    seeded["last_imported_from"] = "/tmp/firm-bundle.zip"
+    seeded["last_imported_at"] = "2026-02-15T12:00:00+00:00"
+    firm_meta_path().write_text(json.dumps(seeded) + "\n", encoding="utf-8")
+
+    # Re-bootstrap (mimics `wbox skills refresh`).
+    update_firm_meta(
+        identity={"id": 1, "name": "Firm"},
+        cli_version="1.1.2",
+        generated_files=["categories.md", "users.md"],
+    )
+
+    after = read_firm_meta()
+    assert after["onboarded_at"] == "2026-01-01T00:00:00+00:00"
+    assert after["last_imported_from"] == "/tmp/firm-bundle.zip"
+    assert after["last_imported_at"] == "2026-02-15T12:00:00+00:00"
+    # Generated keys still update normally.
+    assert after["cli_version"] == "1.1.2"
+    assert set(after["files"]) == {"categories.md", "users.md"}
 
 
 def test_firm_meta_independent_of_template_meta(tmp_path):


### PR DESCRIPTION
## Summary

- After a successful `wbox firm import`, `apply()` stamps `last_imported_from` (the source path/URL) and `last_imported_at` (ISO-8601 timestamp) into the canonical firm `_meta.json` via read-modify-write so generated keys (`identity`, `cli_version`, `files`) survive untouched.
- `wbox doctor` extends the existing `# Firm data` section with a freshness check: if `last_imported_at` is more than 90 days old it prints a warning and adds an issue to the summary, nudging the user to ask their admin for the latest export. Same soft-check shape as the recently-merged 30-day release-staleness nudge — never crashes, never hard-fails.
- Never-imported firms (no `last_imported_*` fields) print no warning; firms imported recently render an informational `imported: <ts> (Xd ago)` line but no nudge.

## Test plan

- [x] `pytest -o "pythonpath=src" -q tests/test_firm_import.py tests/test_doctor_cli.py` (52 passed locally)
- [x] Full test suite: `pytest -o "pythonpath=src" -q` (370 passed, 1 skipped)
- [x] `ruff check src/ tests/` passes
- [x] `apply()` writes both fields on success — `test_apply_writes_last_imported_provenance`
- [x] Provenance write does not clobber generated meta keys — `test_apply_provenance_preserves_existing_generated_keys`
- [x] `apply()` without `source` is a no-op for provenance — `test_apply_without_source_does_not_write_provenance`
- [x] CLI passes the archive path through — `test_firm_import_cli_stamps_provenance`
- [x] Doctor warns when `last_imported_at` > 90 days old — `test_doctor_warns_when_firm_data_imported_more_than_90_days_ago`
- [x] Doctor stays quiet when fields are absent — `test_doctor_no_freshness_warning_when_never_imported`
- [x] Doctor stays quiet on a recent import — `test_doctor_no_freshness_warning_when_imported_recently`

Closes #48

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>