### PR TITLE
feat: firm import merge and abort-on-conflict modes (#46)

### DIFF
--- a/src/wealthbox_tools/cli/firm.py
+++ b/src/wealthbox_tools/cli/firm.py
@@ -59,13 +59,27 @@ def import_firm(
         "-y",
         help="Skip the overwrite confirmation prompt.",
     ),
+    mode: ApplyMode = typer.Option(
+        ApplyMode.OVERWRITE,
+        "--mode",
+        case_sensitive=False,
+        help=(
+            "How to reconcile the archive with the local firm directory: "
+            "'overwrite' (default) replaces every file; 'merge' writes only "
+            "files not already present locally; 'abort-on-conflict' refuses "
+            "to write anything if any file would be replaced."
+        ),
+    ),
 ) -> None:
-    """Import a firm-archive zip into the local firm directory (overwrite mode).
+    """Import a firm-archive zip into the local firm directory.
 
-    Overwrite is the default — every hand-edited policy file in the archive
-    replaces its counterpart in the firm directory. Files in the firm
+    The default mode is ``overwrite`` — every hand-edited policy file in the
+    archive replaces its counterpart in the firm directory. ``merge`` skips
+    files that already exist locally and writes only new ones.
+    ``abort-on-conflict`` refuses to write anything if any file in the
+    archive would replace an existing local file. Files in the firm
     directory that aren't in the archive (generated ``categories.md``,
-    ``custom-fields.md``, ``users.md``) are left untouched.
+    ``custom-fields.md``, ``users.md``) are left untouched in every mode.
     """
     _ensure_firm_migrated()
     try:
@@ -75,13 +89,20 @@ def import_firm(
 
     dest = _firm_dir()
     if not yes:
+        # The verb in the prompt should match the mode, since 'merge' and
+        # 'abort-on-conflict' don't actually overwrite anything.
+        verb = {
+            ApplyMode.OVERWRITE: "Overwrite",
+            ApplyMode.MERGE: "Merge",
+            ApplyMode.ABORT_ON_CONFLICT: "Import",
+        }[mode]
         typer.confirm(
-            f"Overwrite {len(plan.files)} file(s) in {dest}?",
+            f"{verb} {len(plan.files)} file(s) in {dest}?",
             abort=True,
         )
 
     try:
-        result = _apply(plan, dest, ApplyMode.OVERWRITE, source=str(path))
+        result = _apply(plan, dest, mode, source=str(path))
     except ArchiveError as exc:
         raise typer.BadParameter(str(exc)) from exc
     typer.echo(f"Wrote {len(result.written)} file(s) to {dest}.", err=True)

--- a/src/wealthbox_tools/firm/archive.py
+++ b/src/wealthbox_tools/firm/archive.py
@@ -305,11 +305,16 @@ def apply(
 
     if mode is ApplyMode.ABORT_ON_CONFLICT:
         # Only flag genuine file replacements. ``_meta.json`` is
-        # key-merged, not replaced, so it is never a conflict.
+        # key-merged, not replaced, so it is never a conflict. ``is_symlink()``
+        # catches dangling symlinks (where ``exists()`` returns False) so
+        # an existing-symlink local entry still aborts — otherwise the
+        # later ``write_bytes`` would follow the link and write outside
+        # firm_dir, violating the no-write-on-conflict guarantee.
         conflicts = [
             name
             for name in plan.files
-            if name != META_FILENAME and (firm_dir / name).exists()
+            if name != META_FILENAME
+            and ((firm_dir / name).is_symlink() or (firm_dir / name).exists())
         ]
         if conflicts:
             raise ArchiveError(
@@ -325,10 +330,12 @@ def apply(
         if (
             mode is ApplyMode.MERGE
             and name != META_FILENAME
-            and target.exists()
+            and (target.is_symlink() or target.exists())
         ):
             # MERGE skips files that already exist; only _meta.json keeps
             # its merge-into-existing behavior so policy keys still land.
+            # ``is_symlink()`` covers the dangling-symlink case the same
+            # way the ABORT_ON_CONFLICT pre-flight check does.
             continue
         target.parent.mkdir(parents=True, exist_ok=True)
         if name == META_FILENAME:

--- a/src/wealthbox_tools/firm/archive.py
+++ b/src/wealthbox_tools/firm/archive.py
@@ -13,9 +13,10 @@ The user preferences directory (``~/.config/wbox/user/``) is never reachable
 from this module by construction: ``pack`` only sees ``firm_dir``.
 
 Apply modes (overwrite, merge, abort-on-conflict) are exposed as
-:class:`ApplyMode`, but only ``OVERWRITE`` is implemented in the current
-slice — ``MERGE`` and ``ABORT_ON_CONFLICT`` exist as enum values so future
-slices (#46) can wire their behavior in without breaking the public surface.
+:class:`ApplyMode`. ``OVERWRITE`` replaces every file in the plan;
+``MERGE`` skips files that already exist locally and writes only new ones;
+``ABORT_ON_CONFLICT`` raises if any file in the plan would replace an
+existing local file, writing nothing in that case.
 """
 from __future__ import annotations
 
@@ -119,9 +120,13 @@ class ArchiveError(Exception):
 class ApplyMode(StrEnum):
     """How :func:`apply` reconciles archive contents with the firm directory.
 
-    Only ``OVERWRITE`` is implemented in the current slice (#36). ``MERGE``
-    and ``ABORT_ON_CONFLICT`` are placeholders that #46 will wire up against
-    the same :func:`apply` surface.
+    - ``OVERWRITE`` — every file in the plan replaces its destination
+      counterpart; whitelist-only, so files outside the plan stay put.
+    - ``MERGE`` — files that already exist locally are skipped; only
+      genuinely new files are written.
+    - ``ABORT_ON_CONFLICT`` — if any file in the plan would replace an
+      existing local file, raise before writing anything; either every new
+      file is written or none are.
     """
 
     OVERWRITE = "overwrite"
@@ -262,37 +267,69 @@ def apply(
 ) -> ApplyResult:
     """Write the files from ``plan`` into ``firm_dir`` according to ``mode``.
 
-    In ``OVERWRITE`` mode every file in the plan is written unconditionally;
-    files already in ``firm_dir`` that are not in the plan are left alone
-    (the archive is whitelist-only, so generated files like
-    ``categories.md`` survive untouched on the destination).
+    - ``OVERWRITE`` — every file in the plan is written unconditionally.
+    - ``MERGE`` — files that already exist locally are skipped; only
+      genuinely new files are written. ``_meta.json`` is special-cased: it
+      always merges (policy keys overwritten by the archive, generated keys
+      preserved) regardless of mode, since #36's whitelist-symmetry
+      guarantee depends on key-level merge semantics for that file.
+    - ``ABORT_ON_CONFLICT`` — if any file in the plan would replace an
+      existing local file, raise :class:`ArchiveError` before writing
+      anything. ``_meta.json`` is excluded from the conflict check for the
+      same reason it merges in MERGE mode — its policy subset is always
+      welcome to land on top of the existing file.
 
-    ``MERGE`` and ``ABORT_ON_CONFLICT`` are not implemented in this slice
-    and raise :class:`ArchiveError`. Issue #46 will fill them in.
+    Files already in ``firm_dir`` that are not in the plan are left alone
+    in every mode (the archive is whitelist-only, so generated files like
+    ``categories.md`` survive untouched on the destination).
 
     When ``source`` is provided, ``last_imported_from=source`` and
     ``last_imported_at=<now ISO>`` are stamped into ``_meta.json`` (#48).
     These provenance fields power the doctor's 90-day-stale warning. The
     write is read-modify-write into the existing meta — generated keys
     (identity, cli_version, files) survive untouched, just like a normal
-    ``_meta.json`` merge from the archive.
+    ``_meta.json`` merge from the archive. ``ABORT_ON_CONFLICT`` raises
+    before the file loop, so provenance is never stamped on a refused
+    import.
     """
-    if mode is not ApplyMode.OVERWRITE:
-        raise ArchiveError(
-            f"apply mode {mode.value!r} is not implemented yet; only "
-            f"{ApplyMode.OVERWRITE.value!r} is supported in this release."
-        )
-
     firm_dir = Path(firm_dir)
-    firm_dir.mkdir(parents=True, exist_ok=True)
 
-    written: list[str] = []
-    for name, content in plan.files.items():
+    # Validate every plan entry up front so ABORT_ON_CONFLICT can raise
+    # before any filesystem writes, and so MERGE / OVERWRITE never half-
+    # apply a tampered plan.
+    for name in plan.files:
         if not _is_safe_archive_name(name):
             raise ArchiveError(
                 f"plan contains unsafe entry path {name!r}; refusing to write."
             )
+
+    if mode is ApplyMode.ABORT_ON_CONFLICT:
+        # Only flag genuine file replacements. ``_meta.json`` is
+        # key-merged, not replaced, so it is never a conflict.
+        conflicts = [
+            name
+            for name in plan.files
+            if name != META_FILENAME and (firm_dir / name).exists()
+        ]
+        if conflicts:
+            raise ArchiveError(
+                "abort-on-conflict: refusing to import; the following file(s) "
+                f"already exist in {firm_dir}: {', '.join(sorted(conflicts))}."
+            )
+
+    firm_dir.mkdir(parents=True, exist_ok=True)
+
+    written: list[str] = []
+    for name, content in plan.files.items():
         target = firm_dir / name
+        if (
+            mode is ApplyMode.MERGE
+            and name != META_FILENAME
+            and target.exists()
+        ):
+            # MERGE skips files that already exist; only _meta.json keeps
+            # its merge-into-existing behavior so policy keys still land.
+            continue
         target.parent.mkdir(parents=True, exist_ok=True)
         if name == META_FILENAME:
             content = _merge_meta_bytes(target, content)

--- a/tests/test_firm_import.py
+++ b/tests/test_firm_import.py
@@ -1,8 +1,9 @@
 """Tests for ``wbox firm import`` and the underlying ``firm.archive`` unpack/apply.
 
-Issue #36 — overwrite mode only. Sibling slices (#45 URL fetch, #46 merge /
-abort-on-conflict, #47 diff, #48 post-import metadata) are blocked by this
-one and will extend the same ``unpack`` / ``apply`` / ``ApplyMode`` surface.
+Covers all three :class:`ApplyMode` values — ``overwrite`` (#36), and
+``merge`` / ``abort-on-conflict`` (#46) — against the same ``unpack`` /
+``apply`` / CLI surface. Sibling slices (#45 URL fetch, #47 diff, #48
+post-import metadata) extend the same surface separately.
 """
 from __future__ import annotations
 
@@ -408,9 +409,9 @@ def test_firm_import_cli_surfaces_clear_error_on_missing_file(
 
 
 def test_apply_mode_enum_has_three_values() -> None:
-    """The enum carries the three modes named in the brief, even though only
-    overwrite is implemented in this slice — sibling issues #46/#47 wire the
-    others up against the same surface."""
+    """The enum carries the three modes named in the brief: overwrite,
+    merge, and abort-on-conflict. All three are implemented and exposed
+    through the same :func:`apply` surface."""
     assert ApplyMode("overwrite") is ApplyMode.OVERWRITE
     assert ApplyMode("merge") is ApplyMode.MERGE
     assert ApplyMode("abort-on-conflict") is ApplyMode.ABORT_ON_CONFLICT
@@ -561,6 +562,148 @@ def test_apply_without_source_does_not_write_provenance(tmp_path: Path) -> None:
     assert "last_imported_at" not in meta
 
 
+# --------------------------------------------------------------------------- #
+# Apply: merge mode                                                            #
+# --------------------------------------------------------------------------- #
+
+
+def test_apply_merge_skips_existing_files_and_writes_new_ones(tmp_path: Path) -> None:
+    """``MERGE`` writes only files that don't already exist locally.
+
+    The destination has its own ``contacts.md`` and ``tasks.md`` — those
+    should be left untouched. The remaining hand-edited files in the plan
+    don't exist locally yet, so they should land verbatim.
+    """
+    src = tmp_path / "src"
+    bodies = _populated_firm_dir(src)
+    archive = tmp_path / "firm.zip"
+    archive.write_bytes(pack(src, now=_PINNED_NOW))
+
+    dst = tmp_path / "dst"
+    dst.mkdir()
+    local_contacts = "# locally curated contacts policy\n"
+    local_tasks = "# locally curated tasks policy\n"
+    (dst / "contacts.md").write_text(local_contacts, encoding="utf-8")
+    (dst / "tasks.md").write_text(local_tasks, encoding="utf-8")
+
+    plan = unpack(archive)
+    result = apply(plan, dst, ApplyMode.MERGE)
+
+    # Pre-existing local files are preserved.
+    assert (dst / "contacts.md").read_text(encoding="utf-8") == local_contacts
+    assert (dst / "tasks.md").read_text(encoding="utf-8") == local_tasks
+    # Files that didn't exist locally land from the archive.
+    for name in ("notes.md", "events.md", "opportunities.md", "projects.md", "workflows.md"):
+        assert (dst / name).read_text(encoding="utf-8") == bodies[name]
+    # ApplyResult only reports files actually written. _meta.json always
+    # merges (key-level), so it should appear in `written`; the two skipped
+    # markdown files should not.
+    assert "contacts.md" not in result.written
+    assert "tasks.md" not in result.written
+    assert "notes.md" in result.written
+    assert "_meta.json" in result.written
+
+
+def test_apply_merge_meta_still_merges_policy_keys(tmp_path: Path) -> None:
+    """``_meta.json`` is the one entry that key-merges in every mode.
+
+    ``pack`` strips ``_meta.json`` to just the policy subset
+    (``onboarded_at``); skipping it whole in MERGE would mean a firm that
+    re-imports an updated policy never picks up new policy keys, even
+    though no destination data is being clobbered. The key-level merge
+    (policy keys overwritten, generated keys preserved) is the right
+    behavior in MERGE mode too.
+    """
+    src = tmp_path / "src"
+    _populated_firm_dir(src)
+    archive = tmp_path / "firm.zip"
+    archive.write_bytes(pack(src, now=_PINNED_NOW))
+
+    dst = tmp_path / "dst"
+    dst.mkdir()
+    pre_existing = {
+        "identity": {"id": 42, "name": "Local Firm", "user_id": 7},
+        "cli_version": "1.6.0",
+        "files": {"categories.md": "2026-04-01T00:00:00+00:00"},
+        "onboarded_at": "2025-01-01T00:00:00+00:00",
+    }
+    (dst / "_meta.json").write_text(json.dumps(pre_existing, indent=2), encoding="utf-8")
+
+    plan = unpack(archive)
+    apply(plan, dst, ApplyMode.MERGE)
+
+    merged = json.loads((dst / "_meta.json").read_text(encoding="utf-8"))
+    # Policy key from the archive lands.
+    assert merged["onboarded_at"] == "2024-02-15T12:34:56+00:00"
+    # Generated keys survive.
+    assert merged["identity"] == pre_existing["identity"]
+    assert merged["cli_version"] == pre_existing["cli_version"]
+    assert merged["files"] == pre_existing["files"]
+
+
+# --------------------------------------------------------------------------- #
+# Apply: abort-on-conflict mode                                                #
+# --------------------------------------------------------------------------- #
+
+
+def test_apply_abort_on_conflict_raises_and_writes_nothing(tmp_path: Path) -> None:
+    """``ABORT_ON_CONFLICT`` refuses to write anything if any file would be
+    replaced. The whole import is aborted — no partial state, no files
+    written, no provenance stamped. ``_meta.json`` is excluded from the
+    conflict check (it always key-merges), so its presence on disk does
+    not on its own trigger an abort.
+    """
+    src = tmp_path / "src"
+    _populated_firm_dir(src)
+    archive = tmp_path / "firm.zip"
+    archive.write_bytes(pack(src, now=_PINNED_NOW))
+
+    dst = tmp_path / "dst"
+    dst.mkdir()
+    # One pre-existing local hand-edited file should be enough to abort.
+    local_contacts = "# locally curated contacts policy\n"
+    (dst / "contacts.md").write_text(local_contacts, encoding="utf-8")
+
+    plan = unpack(archive)
+    with pytest.raises(ArchiveError) as excinfo:
+        apply(plan, dst, ApplyMode.ABORT_ON_CONFLICT)
+    assert "contacts.md" in str(excinfo.value)
+
+    # The conflicting file must be untouched.
+    assert (dst / "contacts.md").read_text(encoding="utf-8") == local_contacts
+    # No other plan files should have been written either — the abort is
+    # all-or-nothing.
+    for name in ("tasks.md", "notes.md", "events.md", "opportunities.md", "projects.md", "workflows.md"):
+        assert not (dst / name).exists()
+    # And no _meta.json should have been written, since the operation
+    # aborted before any write happened.
+    assert not (dst / "_meta.json").exists()
+
+
+def test_apply_abort_on_conflict_writes_when_no_conflicts(tmp_path: Path) -> None:
+    """When no plan file would replace a local file, ABORT_ON_CONFLICT writes
+    every file in the plan — same shape as OVERWRITE on a clean tree."""
+    src = tmp_path / "src"
+    bodies = _populated_firm_dir(src)
+    archive = tmp_path / "firm.zip"
+    archive.write_bytes(pack(src, now=_PINNED_NOW))
+
+    dst = tmp_path / "dst"
+    dst.mkdir()
+
+    plan = unpack(archive)
+    result = apply(plan, dst, ApplyMode.ABORT_ON_CONFLICT)
+
+    for name, expected in bodies.items():
+        assert (dst / name).read_text(encoding="utf-8") == expected
+    assert set(result.written) == set(bodies) | {"_meta.json"}
+
+
+# --------------------------------------------------------------------------- #
+# CLI: provenance + mode tests                                                 #
+# --------------------------------------------------------------------------- #
+
+
 def test_firm_import_cli_stamps_provenance(runner, tmp_path: Path) -> None:
     """The CLI passes the archive path through to ``apply`` so the user's
     firm dir picks up the freshness fields after a real ``wbox firm import``."""
@@ -577,3 +720,62 @@ def test_firm_import_cli_stamps_provenance(runner, tmp_path: Path) -> None:
     meta = json.loads(firm_meta_path().read_text(encoding="utf-8"))
     assert meta["last_imported_from"] == str(archive)
     assert isinstance(meta.get("last_imported_at"), str) and meta["last_imported_at"]
+
+
+def test_firm_import_cli_merge_mode_skips_existing_files(
+    runner, tmp_path: Path
+) -> None:
+    """`wbox firm import <path> --mode merge --yes` skips files that exist locally."""
+    from wealthbox_tools.cli._skill_paths import firm_dir
+
+    src = tmp_path / "src"
+    bodies = _populated_firm_dir(src)
+    archive = tmp_path / "firm.zip"
+    archive.write_bytes(pack(src, now=_PINNED_NOW))
+
+    fd = firm_dir()
+    fd.mkdir(parents=True, exist_ok=True)
+    local_contacts = "# locally curated\n"
+    (fd / "contacts.md").write_text(local_contacts, encoding="utf-8")
+
+    result = runner.invoke(
+        app, ["firm", "import", str(archive), "--mode", "merge", "--yes"]
+    )
+
+    assert result.exit_code == 0, result.stdout
+    # Existing file preserved.
+    assert (fd / "contacts.md").read_text(encoding="utf-8") == local_contacts
+    # Newly-written file lands.
+    assert (fd / "notes.md").read_text(encoding="utf-8") == bodies["notes.md"]
+
+
+def test_firm_import_cli_abort_on_conflict_mode_aborts_cleanly(
+    runner, tmp_path: Path
+) -> None:
+    """`wbox firm import <path> --mode abort-on-conflict --yes` exits non-zero
+    when any local file would be replaced, and writes nothing."""
+    from wealthbox_tools.cli._skill_paths import firm_dir
+
+    src = tmp_path / "src"
+    _populated_firm_dir(src)
+    archive = tmp_path / "firm.zip"
+    archive.write_bytes(pack(src, now=_PINNED_NOW))
+
+    fd = firm_dir()
+    fd.mkdir(parents=True, exist_ok=True)
+    local_contacts = "# locally curated\n"
+    (fd / "contacts.md").write_text(local_contacts, encoding="utf-8")
+
+    result = runner.invoke(
+        app,
+        ["firm", "import", str(archive), "--mode", "abort-on-conflict", "--yes"],
+    )
+
+    assert result.exit_code != 0
+    combined = (result.stdout or "") + (result.stderr or "")
+    assert "Traceback" not in combined
+    # Conflicting file untouched.
+    assert (fd / "contacts.md").read_text(encoding="utf-8") == local_contacts
+    # And the non-conflicting files were not written either.
+    for name in ("tasks.md", "notes.md", "events.md", "opportunities.md", "projects.md", "workflows.md"):
+        assert not (fd / name).exists()


### PR DESCRIPTION
## Summary

- Wire up `ApplyMode.MERGE` (skip files that already exist locally) and `ApplyMode.ABORT_ON_CONFLICT` (pre-flight check; raise before any write if any planned file would replace an existing local file) against the existing `apply()` surface in `firm/archive.py`.
- Add `--mode {overwrite,merge,abort-on-conflict}` to `wbox firm import`. `overwrite` remains the default and matches the no-flag form. The confirmation prompt's verb adapts to the chosen mode.
- `_meta.json` keeps its key-level merge in every mode (policy keys overwritten, generated `identity`/`cli_version`/`files` preserved); it is excluded from the abort-on-conflict check for the same reason — its presence on disk is never a conflict.

## Test plan

- [x] `pytest -o "pythonpath=src" -q tests/test_firm_import.py` (39 passed)
- [x] Full suite: `pytest -o "pythonpath=src" -q` (369 passed, 1 skipped)
- [x] `ruff check src/ tests/` (clean)
- [x] `wbox firm import --help` shows the three modes with `overwrite` as default

New tests cover:
- `merge` skips pre-existing files and writes new ones; `_meta.json` still key-merges.
- `abort-on-conflict` raises and writes nothing when any planned file would replace a local file; writes everything when there are no conflicts.
- CLI: `--mode merge --yes` skips existing files; `--mode abort-on-conflict --yes` exits non-zero with a clean (non-traceback) message and leaves the firm dir untouched.

Closes #46