### PR TITLE
feat: wbox firm diff (#47)

### DIFF
--- a/src/wealthbox_tools/cli/firm.py
+++ b/src/wealthbox_tools/cli/firm.py
@@ -9,6 +9,8 @@ from ..firm import ApplyMode, ArchiveError
 from ..firm import apply as _apply
 from ..firm import pack as _pack
 from ..firm import unpack as _unpack
+from ..firm.diff import compute_diff as _compute_diff
+from ..firm.diff import format_report as _format_report
 from ._skill_paths import firm_dir as _firm_dir
 from .skills import _ensure_firm_migrated
 
@@ -85,3 +87,36 @@ def import_firm(
     except ArchiveError as exc:
         raise typer.BadParameter(str(exc)) from exc
     typer.echo(f"Wrote {len(result.written)} file(s) to {dest}.", err=True)
+
+
+@app.command("diff")
+def diff_firm(
+    path: Path = typer.Argument(
+        ...,
+        help="Path to a firm-archive zip produced by `wbox firm export`.",
+    ),
+) -> None:
+    """Show a unified diff of a firm-archive zip against the local firm directory.
+
+    Output is a summary header (added / modified / removed counts and
+    filenames) followed by a per-file unified diff in the same format as
+    ``git diff``. Nothing is written to disk — this command is read-only.
+
+    The exit code is ``0`` when the local firm directory matches the
+    archive and non-zero when there are changes, so the command is
+    pipe-checkable (``wbox firm diff foo.zip || echo drift``).
+
+    ``_meta.json`` is intentionally omitted from the diff because the
+    archive carries only the policy-key subset of that file; a bytewise
+    diff against the destination's merged meta would always show drift.
+    """
+    _ensure_firm_migrated()
+    try:
+        plan = _unpack(path)
+    except ArchiveError as exc:
+        raise typer.BadParameter(str(exc)) from exc
+
+    report = _compute_diff(plan, _firm_dir())
+    typer.echo(_format_report(report), nl=False)
+    if report.has_changes:
+        raise typer.Exit(code=1)

--- a/src/wealthbox_tools/firm/diff.py
+++ b/src/wealthbox_tools/firm/diff.py
@@ -157,6 +157,12 @@ def _unified(a: bytes, b: bytes, *, a_label: str, b_label: str) -> str:
     Bytes are decoded as UTF-8 with ``errors="replace"`` so a stray binary
     payload doesn't crash the diff (the archive whitelist makes binaries
     unlikely, but defensiveness costs nothing here).
+
+    Files that don't end with ``\\n`` cause ``difflib.unified_diff`` to emit
+    ``-``/``+`` records without terminators; joining those verbatim
+    concatenates lines (``-old+new``) and corrupts the next file header.
+    Append a git-style ``\\ No newline at end of file`` marker after any
+    such record so the output stays parseable as unified diff.
     """
     a_text = a.decode("utf-8", errors="replace").splitlines(keepends=True)
     b_text = b.decode("utf-8", errors="replace").splitlines(keepends=True)
@@ -167,7 +173,20 @@ def _unified(a: bytes, b: bytes, *, a_label: str, b_label: str) -> str:
         tofile=f"b/{b_label}",
         n=3,
     )
-    return "".join(lines)
+    return "".join(_terminate(line) for line in lines)
+
+
+def _terminate(line: str) -> str:
+    """Ensure a unified-diff line ends with ``\\n``.
+
+    Adds the git ``\\ No newline at end of file`` marker after content
+    lines (``-`` / ``+`` / ` `) that lack a terminator. Header lines
+    (``---``, ``+++``, ``@@``) always come from ``difflib`` already
+    terminated and pass through unchanged.
+    """
+    if line.endswith("\n"):
+        return line
+    return line + "\n\\ No newline at end of file\n"
 
 
 def format_report(report: DiffReport) -> str:

--- a/src/wealthbox_tools/firm/diff.py
+++ b/src/wealthbox_tools/firm/diff.py
@@ -1,0 +1,214 @@
+"""Read-only diff between an :class:`~.archive.ImportPlan` and a firm directory.
+
+``firm diff`` (issue #47) reuses :func:`~.archive.unpack` to read the
+archive, then walks the resulting plan + firm directory and produces a
+unified-diff per changed file. Nothing is written; the firm dir is
+read-only here.
+
+``_meta.json`` is intentionally excluded from the diff. Pack strips it to
+the policy-key subset (``META_POLICY_KEYS``) and apply merges that subset
+into the destination — a bytewise diff would always show drift between the
+archive's stripped meta and the destination's merged meta even when the
+firm and the archive are in lockstep on policy. Skipping the file
+sidesteps that false-positive without giving up anything we'd notice in
+practice (the only policy key today is ``onboarded_at``, which doesn't
+benefit from a per-line diff). If a future schema makes per-key meta diff
+useful, swap this for the META_POLICY_KEYS subset diff (Option B in the
+issue brief).
+"""
+from __future__ import annotations
+
+import difflib
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from .archive import HAND_EDITED_FILES, META_FILENAME, ImportPlan
+
+
+@dataclass(frozen=True)
+class DiffEntry:
+    """A single per-file unified diff."""
+
+    name: str
+    body: str  # the unified-diff text, may be empty when there's no body to show
+
+
+@dataclass(frozen=True)
+class DiffReport:
+    """The result of comparing an :class:`ImportPlan` against a firm directory.
+
+    Buckets are mutually exclusive: a file appears in exactly one of
+    ``added``/``modified``/``removed``. ``has_changes`` is true if any
+    bucket is non-empty — callers use it to set the process exit code so
+    ``firm diff`` is pipe-checkable.
+    """
+
+    added: tuple[str, ...] = ()
+    modified: tuple[str, ...] = ()
+    removed: tuple[str, ...] = ()
+    diffs: tuple[DiffEntry, ...] = field(default_factory=tuple)
+
+    @property
+    def has_changes(self) -> bool:
+        return bool(self.added or self.modified or self.removed)
+
+
+def compute_diff(plan: ImportPlan, firm_dir: Path) -> DiffReport:
+    """Compute the per-file diff between ``plan`` and ``firm_dir``.
+
+    "Added" = in plan, not on disk. "Modified" = both sides have it but
+    the bytes differ (after line-ending normalization — see below).
+    "Removed" = on disk under ``firm_dir`` (within the hand-edited
+    whitelist), not in the plan. Removed is conceptual — the archive
+    doesn't carry the file, so a subsequent overwrite-mode import
+    wouldn't re-create it; the diff command never deletes anything.
+
+    Line endings are normalized to ``\\n`` on both sides before comparison
+    because ``pack`` stores files with whatever line endings they had on
+    disk and zip storage is byte-for-byte, but the destination on disk
+    may have ``\\r\\n`` (Windows) or ``\\n`` (Unix) depending on the host.
+    Without normalization every file would surface as "modified" on
+    Windows even when the content is in lockstep.
+
+    ``_meta.json`` is excluded from the comparison — see module docstring.
+    """
+    firm_dir = Path(firm_dir)
+
+    # Plan side: every entry except _meta.json. Anything outside the
+    # hand-edited whitelist is impossible by construction (unpack rejects
+    # it), but we still filter defensively rather than trust the plan.
+    plan_files: dict[str, bytes] = {
+        name: _normalize_eol(blob)
+        for name, blob in plan.files.items()
+        if name != META_FILENAME and name in HAND_EDITED_FILES
+    }
+
+    # Disk side: only inspect the hand-edited whitelist. Generated files
+    # (categories.md, custom-fields.md, users.md) live in firm_dir but are
+    # not policy — they don't travel with the archive and reporting them
+    # as "removed" would be misleading noise.
+    disk_files: dict[str, bytes] = {}
+    if firm_dir.is_dir():
+        for name in HAND_EDITED_FILES:
+            target = firm_dir / name
+            if target.is_file() and not target.is_symlink():
+                disk_files[name] = _normalize_eol(target.read_bytes())
+
+    added: list[str] = []
+    modified: list[str] = []
+    removed: list[str] = []
+    diffs: list[DiffEntry] = []
+
+    plan_names = set(plan_files)
+    disk_names = set(disk_files)
+
+    for name in sorted(plan_names | disk_names):
+        in_plan = name in plan_files
+        in_disk = name in disk_files
+        if in_plan and not in_disk:
+            added.append(name)
+            diffs.append(
+                DiffEntry(
+                    name=name,
+                    body=_unified(b"", plan_files[name], a_label=name, b_label=name),
+                )
+            )
+        elif in_disk and not in_plan:
+            removed.append(name)
+            diffs.append(
+                DiffEntry(
+                    name=name,
+                    body=_unified(disk_files[name], b"", a_label=name, b_label=name),
+                )
+            )
+        else:
+            disk_blob = disk_files[name]
+            plan_blob = plan_files[name]
+            if disk_blob == plan_blob:
+                continue
+            modified.append(name)
+            diffs.append(
+                DiffEntry(
+                    name=name,
+                    body=_unified(disk_blob, plan_blob, a_label=name, b_label=name),
+                )
+            )
+
+    return DiffReport(
+        added=tuple(added),
+        modified=tuple(modified),
+        removed=tuple(removed),
+        diffs=tuple(diffs),
+    )
+
+
+def _normalize_eol(blob: bytes) -> bytes:
+    """Collapse ``\\r\\n`` and lone ``\\r`` to ``\\n``.
+
+    Used by :func:`compute_diff` so a Windows checkout (CRLF on disk)
+    matches a zip-stored body (LF) when the textual content is identical.
+    """
+    return blob.replace(b"\r\n", b"\n").replace(b"\r", b"\n")
+
+
+def _unified(a: bytes, b: bytes, *, a_label: str, b_label: str) -> str:
+    """Return the unified-diff body for ``a`` vs ``b``.
+
+    Bytes are decoded as UTF-8 with ``errors="replace"`` so a stray binary
+    payload doesn't crash the diff (the archive whitelist makes binaries
+    unlikely, but defensiveness costs nothing here).
+    """
+    a_text = a.decode("utf-8", errors="replace").splitlines(keepends=True)
+    b_text = b.decode("utf-8", errors="replace").splitlines(keepends=True)
+    lines = difflib.unified_diff(
+        a_text,
+        b_text,
+        fromfile=f"a/{a_label}",
+        tofile=f"b/{b_label}",
+        n=3,
+    )
+    return "".join(lines)
+
+
+def format_report(report: DiffReport) -> str:
+    """Render a :class:`DiffReport` as text suitable for ``stdout``.
+
+    Layout::
+
+        Added (1):
+          contacts.md
+        Modified (2):
+          tasks.md
+          notes.md
+        Removed (1):
+          events.md
+
+        --- a/contacts.md
+        +++ b/contacts.md
+        @@ ... @@
+        ...
+
+    When the report has no changes, returns ``"No changes.\\n"`` so the
+    caller can still echo *something* to stdout — handy when piping.
+    """
+    if not report.has_changes:
+        return "No changes.\n"
+
+    lines: list[str] = []
+    if report.added:
+        lines.append(f"Added ({len(report.added)}):")
+        lines.extend(f"  {n}" for n in report.added)
+    if report.modified:
+        lines.append(f"Modified ({len(report.modified)}):")
+        lines.extend(f"  {n}" for n in report.modified)
+    if report.removed:
+        lines.append(f"Removed ({len(report.removed)}):")
+        lines.extend(f"  {n}" for n in report.removed)
+
+    out = "\n".join(lines) + "\n"
+    bodies = [d.body for d in report.diffs if d.body]
+    if bodies:
+        out += "\n" + "".join(bodies)
+        if not out.endswith("\n"):
+            out += "\n"
+    return out

--- a/tests/test_firm_diff.py
+++ b/tests/test_firm_diff.py
@@ -212,6 +212,28 @@ def test_firm_diff_skips_meta_json_noise(runner, tmp_path: Path) -> None:
     assert "_meta.json" not in combined
 
 
+def test_firm_diff_handles_missing_trailing_newline(tmp_path: Path) -> None:
+    """When either side of a changed file lacks a trailing newline,
+    ``difflib.unified_diff`` returns ``-``/``+`` records without
+    terminators. The renderer must add a git-style
+    ``\\ No newline at end of file`` marker so the output stays parseable
+    as unified diff — otherwise lines glue together (``-old+new``) and
+    can corrupt the next file header.
+    """
+    from wealthbox_tools.firm.diff import _unified
+
+    rendered = _unified(b"old", b"new", a_label="contacts.md", b_label="contacts.md")
+    # No "-old+new" concatenation.
+    assert "-old+new" not in rendered
+    # Both sides surface as separate records, each followed by the marker.
+    assert "-old\n\\ No newline at end of file\n" in rendered
+    assert "+new\n\\ No newline at end of file\n" in rendered
+    # And every emitted line ends with a newline so a downstream consumer
+    # (`splitlines`, a patch tool, etc.) parses it cleanly.
+    for line in rendered.splitlines(keepends=True):
+        assert line.endswith("\n"), repr(line)
+
+
 def test_firm_diff_surfaces_clear_error_on_missing_archive(
     runner, tmp_path: Path
 ) -> None:

--- a/tests/test_firm_diff.py
+++ b/tests/test_firm_diff.py
@@ -1,0 +1,225 @@
+"""Tests for ``wbox firm diff`` — read-only unified-diff against the firm dir.
+
+Issue #47. ``firm diff`` reuses :func:`unpack` from ``firm.archive`` so the
+same path/URL surface as ``firm import`` is honored. Output is a summary
+header listing added / modified / removed files plus per-file unified
+diffs. Exit code is ``0`` when nothing differs and non-zero otherwise so
+callers can pipe-check.
+
+``_meta.json`` is intentionally skipped from the per-file diff because the
+archive carries only the policy-key subset (``META_POLICY_KEYS``) and apply
+merges that subset into the destination — a bytewise diff would always
+report drift even when the firm is in lockstep with the archive.
+"""
+from __future__ import annotations
+
+import io
+import json
+import zipfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+from wealthbox_tools.cli.main import app
+from wealthbox_tools.firm.archive import pack
+
+# --------------------------------------------------------------------------- #
+# Helpers                                                                      #
+# --------------------------------------------------------------------------- #
+
+
+_PINNED_NOW = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+
+def _populated_firm_dir(root: Path) -> dict[str, str]:
+    """Create a firm dir with the same shape used by the import-side tests."""
+    root.mkdir(parents=True, exist_ok=True)
+    bodies = {
+        "contacts.md": "# Contacts policy\n\nUse household-first onboarding.\n",
+        "tasks.md": "# Tasks policy\n\nDefault priority is medium.\n",
+        "notes.md": "# Notes policy\n",
+        "events.md": "# Events policy\n",
+        "opportunities.md": "# Opportunities policy\n",
+        "projects.md": "# Projects policy\n",
+        "workflows.md": "# Workflows policy\n",
+    }
+    for name, body in bodies.items():
+        (root / name).write_text(body, encoding="utf-8")
+    (root / "_meta.json").write_text(
+        json.dumps({"onboarded_at": "2024-02-15T12:34:56+00:00"}, indent=2),
+        encoding="utf-8",
+    )
+    return bodies
+
+
+def _zip_with_manifest(
+    path: Path,
+    manifest: dict,
+    bodies: dict[str, str] | None = None,
+) -> Path:
+    """Hand-craft a zip archive with the given manifest and optional file bodies."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, mode="w", compression=zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr(".manifest.json", json.dumps(manifest, indent=2) + "\n")
+        for name, body in (bodies or {}).items():
+            zf.writestr(name, body)
+    path.write_bytes(buf.getvalue())
+    return path
+
+
+# --------------------------------------------------------------------------- #
+# Identical zip — empty change list, exit 0                                    #
+# --------------------------------------------------------------------------- #
+
+
+def test_firm_diff_identical_zip_reports_no_changes(runner, tmp_path: Path) -> None:
+    """When the firm dir matches the archive byte-for-byte, ``firm diff``
+    prints an empty change list and exits ``0`` so it's pipe-checkable."""
+    from wealthbox_tools.cli._skill_paths import firm_dir
+
+    src = tmp_path / "src"
+    bodies = _populated_firm_dir(src)
+    archive = tmp_path / "firm.zip"
+    archive.write_bytes(pack(src, now=_PINNED_NOW))
+
+    fd = firm_dir()
+    fd.mkdir(parents=True, exist_ok=True)
+    for name, body in bodies.items():
+        (fd / name).write_text(body, encoding="utf-8")
+
+    result = runner.invoke(app, ["firm", "diff", str(archive)])
+
+    assert result.exit_code == 0, result.stdout
+    combined = (result.stdout or "") + (result.stderr or "")
+    # No per-file diff bodies — at most a "no changes" summary line.
+    assert "@@" not in combined
+    assert "Traceback" not in combined
+
+
+# --------------------------------------------------------------------------- #
+# Mixed changes — added / modified / removed all surface                       #
+# --------------------------------------------------------------------------- #
+
+
+def test_firm_diff_mixed_changes_surface_in_summary_and_unified_diff(
+    runner, tmp_path: Path
+) -> None:
+    """Added + modified + removed files show up in the summary header and the
+    per-file unified diffs match the unified-diff format that callers can
+    feed into ``patch`` etc.
+
+    Setup:
+      - archive has contacts.md (NEW vs disk), tasks.md (modified vs disk),
+        notes.md (modified vs disk).
+      - firm dir has tasks.md (older), notes.md (older), events.md (REMOVED:
+        on disk only, not in archive).
+    """
+    from wealthbox_tools.cli._skill_paths import firm_dir
+
+    # Build an archive with three of the seven hand-edited files.
+    src = tmp_path / "src"
+    src.mkdir()
+    archive_bodies = {
+        "contacts.md": "# Contacts policy\n\nUse household-first onboarding.\n",
+        "tasks.md": "# Tasks policy\n\nDefault priority is HIGH.\n",
+        "notes.md": "# Notes policy\n\nAlways link to the household.\n",
+    }
+    for name, body in archive_bodies.items():
+        (src / name).write_text(body, encoding="utf-8")
+    (src / "_meta.json").write_text(
+        json.dumps({"onboarded_at": "2024-02-15T12:34:56+00:00"}, indent=2),
+        encoding="utf-8",
+    )
+    archive = tmp_path / "firm.zip"
+    archive.write_bytes(pack(src, now=_PINNED_NOW))
+
+    # Populate the local firm dir.
+    fd = firm_dir()
+    fd.mkdir(parents=True, exist_ok=True)
+    # Modified vs archive
+    (fd / "tasks.md").write_text(
+        "# Tasks policy\n\nDefault priority is medium.\n", encoding="utf-8"
+    )
+    (fd / "notes.md").write_text("# Notes policy\n", encoding="utf-8")
+    # On disk but not in archive — surfaces as "removed".
+    (fd / "events.md").write_text("# Events policy\n", encoding="utf-8")
+    # contacts.md intentionally not on disk → surfaces as "added".
+
+    result = runner.invoke(app, ["firm", "diff", str(archive)])
+
+    # Changes detected → non-zero exit so callers can pipe-check.
+    assert result.exit_code != 0
+    combined = (result.stdout or "") + (result.stderr or "")
+    assert "Traceback" not in combined
+
+    # Summary header lists every category.
+    assert "contacts.md" in combined
+    assert "tasks.md" in combined
+    assert "notes.md" in combined
+    assert "events.md" in combined
+
+    # Buckets are labelled — the user needs to know which file is which.
+    lower = combined.lower()
+    assert "added" in lower
+    assert "modified" in lower
+    assert "removed" in lower
+
+    # Per-file unified diff body is present (hunk header + file headers).
+    assert "@@" in combined
+    assert "--- " in combined
+    assert "+++ " in combined
+
+    # The modified body for tasks.md shows both the old (disk) line and the
+    # new (archive) line — that's how unified diff carries the change.
+    assert "-Default priority is medium." in combined
+    assert "+Default priority is HIGH." in combined
+
+
+def test_firm_diff_skips_meta_json_noise(runner, tmp_path: Path) -> None:
+    """``_meta.json`` must not appear in the diff output even though
+    ``pack`` strips it to the policy subset and the destination on disk
+    carries generated keys (identity / cli_version / files). A bytewise
+    diff would always show drift here — the diff command sidesteps that
+    noise so the output reflects real policy drift only."""
+    from wealthbox_tools.cli._skill_paths import firm_dir
+
+    src = tmp_path / "src"
+    bodies = _populated_firm_dir(src)
+    archive = tmp_path / "firm.zip"
+    archive.write_bytes(pack(src, now=_PINNED_NOW))
+
+    fd = firm_dir()
+    fd.mkdir(parents=True, exist_ok=True)
+    for name, body in bodies.items():
+        (fd / name).write_text(body, encoding="utf-8")
+    # Destination meta has the generated keys that pack strips.
+    (fd / "_meta.json").write_text(
+        json.dumps(
+            {
+                "identity": {"id": 1, "name": "Local Firm", "user_id": 1},
+                "cli_version": "1.6.0",
+                "files": {"categories.md": "2026-04-01T00:00:00+00:00"},
+                "onboarded_at": "2024-02-15T12:34:56+00:00",
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, ["firm", "diff", str(archive)])
+
+    assert result.exit_code == 0, result.stdout
+    combined = (result.stdout or "") + (result.stderr or "")
+    assert "_meta.json" not in combined
+
+
+def test_firm_diff_surfaces_clear_error_on_missing_archive(
+    runner, tmp_path: Path
+) -> None:
+    """A missing archive path exits cleanly via BadParameter, not a stack trace —
+    matches the ``import_firm`` error contract."""
+    missing = tmp_path / "nope.zip"
+    result = runner.invoke(app, ["firm", "diff", str(missing)])
+
+    assert result.exit_code != 0
+    combined = (result.stdout or "") + (result.stderr or "")
+    assert "Traceback" not in combined


### PR DESCRIPTION
## Summary

Builds the `wbox firm diff <path-or-url>` command end-to-end. Reuses `firm.archive.unpack()` so the path/URL surface stays in lockstep with `firm import`. Output is a summary header (Added / Modified / Removed) followed by per-file unified diffs in `git diff` format. Nothing is written — read-only.

Exit code is `0` when the firm dir matches the archive, `1` when there's drift, so the command is pipe-checkable: `wbox firm diff foo.zip || echo drift`.

## `_meta.json` strategy: Option A (skip entirely)

`pack` strips `_meta.json` to the `META_POLICY_KEYS` subset and `apply` merges that subset into the destination — a bytewise diff would always show drift between the archive's stripped meta and the destination's merged meta even when the firm and archive are in lockstep on policy. Skipping the file sidesteps that false positive without giving up anything we'd notice today (the only policy key currently is `onboarded_at`, which doesn't benefit from a per-line diff). If a future schema makes per-key meta diff useful, swap this for the `META_POLICY_KEYS`-subset diff (Option B) — the comment in `firm/diff.py` flags the swap point.

Also normalize `\r\n` / `\r` to `\n` before comparison — without this, every file on Windows surfaces as "modified" because zip stores LF and `write_text` on Windows produces CRLF on disk. The diff bodies themselves use the normalized form too, so the unified-diff stays clean on either platform.

## Test plan

- [x] `pytest -o "pythonpath=src" -q tests/test_firm_diff.py` — 4 passed
  - identical zip = empty change list + exit 0
  - mixed changes (added + modified + removed) all surface in the summary and per-file unified diffs
  - `_meta.json` doesn't appear in the diff output even when destination has generated keys (identity / cli_version / files)
  - missing archive path exits cleanly via BadParameter
- [x] `pytest -o "pythonpath=src" -q tests/test_firm_import.py tests/test_firm_export.py tests/test_firm_diff.py` — 49 passed (no regressions in sibling commands)
- [x] `ruff check src/ tests/` — clean

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)