### PR TITLE
fix: self-upgrade checksum manifest filename

### DIFF
--- a/src/wealthbox_tools/self_upgrade.py
+++ b/src/wealthbox_tools/self_upgrade.py
@@ -7,7 +7,7 @@ functions plus two dataclasses:
   compares to the installed ``__version__``, and returns a populated
   :class:`NewVersion` when an upgrade is available (otherwise ``None``).
 - ``apply(version, install_root)`` downloads the platform-specific binary,
-  verifies its SHA-256 against the release's ``checksums.txt`` manifest,
+  verifies its SHA-256 against the release's ``SHA256SUMS.txt`` manifest,
   and atomically swaps it into place. The previous binary is preserved
   under a ``.old.<unix_ts>`` breadcrumb for rollback / future cleanup
   (issue #39).
@@ -56,7 +56,7 @@ __all__ = [
 _RELEASES_LATEST_URL = (
     "https://api.github.com/repos/massive-value/wealthbox-cli/releases/latest"
 )
-_CHECKSUMS_ASSET_NAME = "checksums.txt"
+_CHECKSUMS_ASSET_NAME = "SHA256SUMS.txt"
 _HTTP_TIMEOUT = httpx.Timeout(30.0)
 
 # Retention window for `<binary>.old.<unix_ts>` rollback breadcrumbs. After

--- a/tests/test_self_upgrade.py
+++ b/tests/test_self_upgrade.py
@@ -54,7 +54,7 @@ def test_check_returns_none_when_up_to_date() -> None:
             _asset("wbox-linux-x64", "https://example.com/wbox-linux-x64"),
             _asset("wbox-macos-x64", "https://example.com/wbox-macos-x64"),
             _asset("wbox-windows-x64.exe", "https://example.com/wbox-windows-x64.exe"),
-            _asset("checksums.txt", "https://example.com/checksums.txt"),
+            _asset("SHA256SUMS.txt", "https://example.com/SHA256SUMS.txt"),
         ],
     )
     respx.get(_RELEASES_URL).mock(return_value=httpx.Response(200, json=payload))
@@ -73,7 +73,7 @@ def test_check_returns_candidate_when_outdated(monkeypatch) -> None:
     body = b"new-binary-bytes"
     digest = hashlib.sha256(body).hexdigest()
     binary_url = "https://example.com/wbox-linux-x64"
-    checksums_url = "https://example.com/checksums.txt"
+    checksums_url = "https://example.com/SHA256SUMS.txt"
     checksums_body = (
         f"{digest}  wbox-linux-x64\n"
         f"deadbeef  wbox-macos-x64\n"
@@ -89,7 +89,7 @@ def test_check_returns_candidate_when_outdated(monkeypatch) -> None:
                     _asset("wbox-linux-x64", binary_url),
                     _asset("wbox-macos-x64", "https://example.com/wbox-macos-x64"),
                     _asset("wbox-windows-x64.exe", "https://example.com/wbox-windows-x64.exe"),
-                    _asset("checksums.txt", checksums_url),
+                    _asset("SHA256SUMS.txt", checksums_url),
                 ],
             ),
         )
@@ -883,7 +883,7 @@ def test_self_upgrade_cli_no_op_when_up_to_date(runner) -> None:
                 tag,
                 [
                     _asset("wbox-linux-x64", "https://example.com/wbox-linux-x64"),
-                    _asset("checksums.txt", "https://example.com/checksums.txt"),
+                    _asset("SHA256SUMS.txt", "https://example.com/SHA256SUMS.txt"),
                 ],
             ),
         )


### PR DESCRIPTION
## Summary
- `src/wealthbox_tools/self_upgrade.py` was requesting `checksums.txt` from the release assets, but `.github/workflows/release-binaries.yml` ships the manifest as `SHA256SUMS.txt`. As a result `wbox self upgrade` could never find the manifest and silently returned no upgrade candidate.
- The workflow contract is canonical (it documents `Manifest filename: SHA256SUMS.txt` as LOCKED). Renamed the `_CHECKSUMS_ASSET_NAME` constant and the docstring reference in `self_upgrade.py`, plus the matching test fixtures in `tests/test_self_upgrade.py`.

## Test plan
- [x] `ruff check src/ tests/` passes
- [x] `pytest -o "pythonpath=src" -q tests/test_self_upgrade.py` passes (31 passed, 1 skipped — the skipped one is the POSIX-only chmod test on this Windows runner)
- [x] No remaining `checksums.txt` references in `src/` or `tests/`

Closes #78