### PR TITLE
feat: firm import URL fetch (#45)

### DIFF
--- a/src/wealthbox_tools/cli/firm.py
+++ b/src/wealthbox_tools/cli/firm.py
@@ -51,9 +51,13 @@ def export_firm(
 
 @app.command("import")
 def import_firm(
-    path: Path = typer.Argument(
+    source: str = typer.Argument(
         ...,
-        help="Path to a firm-archive zip produced by `wbox firm export`.",
+        metavar="PATH_OR_URL",
+        help=(
+            "Local path or HTTP(S) URL of a firm-archive zip produced by "
+            "`wbox firm export`."
+        ),
     ),
     yes: bool = typer.Option(
         False,
@@ -75,6 +79,10 @@ def import_firm(
 ) -> None:
     """Import a firm-archive zip into the local firm directory.
 
+    ``PATH_OR_URL`` may be a local zip file produced by ``wbox firm export``
+    or an HTTP(S) URL serving the same archive — URLs are fetched once via
+    a single GET and then unpacked identically.
+
     The default mode is ``overwrite`` — every hand-edited policy file in the
     archive replaces its counterpart in the firm directory. ``merge`` skips
     files that already exist locally and writes only new ones.
@@ -84,8 +92,15 @@ def import_firm(
     ``custom-fields.md``, ``users.md``) are left untouched in every mode.
     """
     _ensure_firm_migrated()
+    # Treat http(s) strings as URLs so unpack() fetches over the network;
+    # everything else is a local path.
+    archive_source: str | Path = (
+        source
+        if source.startswith("https://") or source.startswith("http://")
+        else Path(source)
+    )
     try:
-        plan = _unpack(path)
+        plan = _unpack(archive_source)
     except ArchiveError as exc:
         raise typer.BadParameter(str(exc)) from exc
 
@@ -104,7 +119,7 @@ def import_firm(
         )
 
     try:
-        result = _apply(plan, dest, mode, source=str(path))
+        result = _apply(plan, dest, mode, source=str(archive_source))
     except ArchiveError as exc:
         raise typer.BadParameter(str(exc)) from exc
     typer.echo(f"Wrote {len(result.written)} file(s) to {dest}.", err=True)

--- a/src/wealthbox_tools/firm/archive.py
+++ b/src/wealthbox_tools/firm/archive.py
@@ -31,6 +31,8 @@ from importlib.metadata import version as _pkg_version
 from pathlib import Path
 from typing import Any
 
+import httpx
+
 #: Manifest schema version. Bump on backwards-incompatible changes.
 FORMAT_VERSION = 1
 
@@ -183,37 +185,81 @@ class ApplyResult:
     written: tuple[str, ...]
 
 
-def unpack(source: Path | str) -> ImportPlan:
-    """Read a firm-archive zip from disk and return its :class:`ImportPlan`.
+def _looks_like_url(source: Path | str) -> bool:
+    """Return ``True`` if ``source`` is a string with an http(s) scheme.
 
-    URL fetch is deferred to issue #45; ``source`` is treated as a local
-    filesystem path for now.
+    URL discrimination happens at the type/prefix level — a ``Path`` is
+    always treated as a local file, a ``str`` with an http(s) prefix is
+    fetched, and any other ``str`` falls through to the local-path branch
+    so existing call sites that pass ``str(path)`` keep working.
+    """
+    return isinstance(source, str) and (
+        source.startswith("https://") or source.startswith("http://")
+    )
+
+
+def _fetch_url_bytes(url: str) -> bytes:
+    """GET ``url`` once and return the body bytes.
+
+    Network errors and non-2xx responses are surfaced as :class:`ArchiveError`
+    with a clean message so the CLI's ``except ArchiveError`` branch reaches
+    the user without a stack trace. Timeout matches the Wealthbox client
+    (30s); redirects are followed because firm archives are commonly served
+    via short links / CDN redirects.
+    """
+    try:
+        response = httpx.get(url, follow_redirects=True, timeout=30.0)
+    except httpx.RequestError as exc:
+        raise ArchiveError(f"{url}: failed to fetch archive: {exc}") from exc
+    if response.is_error:
+        raise ArchiveError(
+            f"{url}: HTTP {response.status_code} fetching archive."
+        )
+    return response.content
+
+
+def unpack(source: Path | str) -> ImportPlan:
+    """Read a firm-archive zip and return its :class:`ImportPlan`.
+
+    ``source`` may be a local filesystem path (``Path`` or ``str``) or an
+    HTTP(S) URL string. URLs are fetched with a single GET via ``httpx``;
+    the returned bytes are then parsed identically to the local-path code
+    path.
 
     Raises:
         ArchiveError: the file isn't a valid zip, the manifest is missing
-            or malformed, or the manifest's ``format_version`` is newer
-            than this CLI understands.
+            or malformed, the manifest's ``format_version`` is newer than
+            this CLI understands, or the URL fetch failed (network error
+            or non-2xx response).
     """
-    path = Path(source)
+    if _looks_like_url(source):
+        url = str(source)
+        label = url
+        zip_input: Path | io.BytesIO = io.BytesIO(_fetch_url_bytes(url))
+    else:
+        path = Path(source)
+        label = str(path)
+        zip_input = path
+
     try:
-        with zipfile.ZipFile(path, mode="r") as zf:
+        with zipfile.ZipFile(zip_input, mode="r") as zf:
             try:
                 manifest_raw = zf.read(MANIFEST_NAME)
             except KeyError as exc:
                 raise ArchiveError(
-                    f"{path}: archive is missing {MANIFEST_NAME}; not a firm archive."
+                    f"{label}: archive is missing {MANIFEST_NAME}; not a firm archive."
                 ) from exc
             entry_names = [n for n in zf.namelist() if n != MANIFEST_NAME]
             allowed = set(HAND_EDITED_FILES) | {META_FILENAME}
             for entry in entry_names:
                 if not _is_safe_archive_name(entry):
                     raise ArchiveError(
-                        f"{path}: archive contains unsafe entry path {entry!r}; "
+                        f"{label}: archive contains unsafe entry path {entry!r}; "
                         "refusing to import."
                     )
                 if entry not in allowed:
                     raise ArchiveError(
-                        f"{path}: archive contains non-policy entry {entry!r}; "
+                        f"{label}: archive contains non-policy entry {entry!r}; "
                         "only hand-edited policy files and _meta.json are accepted."
                     )
             files = {name: zf.read(name) for name in entry_names}
@@ -226,30 +272,30 @@ def unpack(source: Path | str) -> ImportPlan:
                     meta_obj = json.loads(files[META_FILENAME].decode("utf-8"))
                 except (json.JSONDecodeError, UnicodeDecodeError) as exc:
                     raise ArchiveError(
-                        f"{path}: {META_FILENAME} is not valid JSON."
+                        f"{label}: {META_FILENAME} is not valid JSON."
                     ) from exc
                 if not isinstance(meta_obj, dict):
                     raise ArchiveError(
-                        f"{path}: {META_FILENAME} must be a JSON object."
+                        f"{label}: {META_FILENAME} must be a JSON object."
                     )
     except zipfile.BadZipFile as exc:
-        raise ArchiveError(f"{path}: not a valid zip archive.") from exc
+        raise ArchiveError(f"{label}: not a valid zip archive.") from exc
     except FileNotFoundError as exc:
-        raise ArchiveError(f"{path}: archive file not found.") from exc
+        raise ArchiveError(f"{label}: archive file not found.") from exc
     except OSError as exc:
-        raise ArchiveError(f"{path}: cannot read archive: {exc}") from exc
+        raise ArchiveError(f"{label}: cannot read archive: {exc}") from exc
 
     try:
         manifest = json.loads(manifest_raw.decode("utf-8"))
     except (json.JSONDecodeError, UnicodeDecodeError) as exc:
-        raise ArchiveError(f"{path}: {MANIFEST_NAME} is not valid JSON.") from exc
+        raise ArchiveError(f"{label}: {MANIFEST_NAME} is not valid JSON.") from exc
     if not isinstance(manifest, dict):
-        raise ArchiveError(f"{path}: {MANIFEST_NAME} must be a JSON object.")
+        raise ArchiveError(f"{label}: {MANIFEST_NAME} must be a JSON object.")
 
     version = manifest.get("format_version")
     if not isinstance(version, int) or version > FORMAT_VERSION:
         raise ArchiveError(
-            f"{path}: unsupported format_version {version!r}. "
+            f"{label}: unsupported format_version {version!r}. "
             f"This CLI understands format_version up to {FORMAT_VERSION}; "
             "upgrade `wealthbox-cli` to read this archive."
         )

--- a/tests/test_firm_import.py
+++ b/tests/test_firm_import.py
@@ -13,7 +13,9 @@ import zipfile
 from datetime import datetime, timezone
 from pathlib import Path
 
+import httpx
 import pytest
+import respx
 
 from wealthbox_tools.cli.main import app
 from wealthbox_tools.firm.archive import (
@@ -779,3 +781,126 @@ def test_firm_import_cli_abort_on_conflict_mode_aborts_cleanly(
     # And the non-conflicting files were not written either.
     for name in ("tasks.md", "notes.md", "events.md", "opportunities.md", "projects.md", "workflows.md"):
         assert not (fd / name).exists()
+
+
+# --------------------------------------------------------------------------- #
+# URL fetch (#45)                                                             #
+# --------------------------------------------------------------------------- #
+
+
+@respx.mock
+def test_unpack_fetches_url_with_single_get(tmp_path: Path) -> None:
+    """``unpack("https://...")`` performs a single GET and operates on the
+    returned bytes identically to the local-path code path.
+
+    The URL branch is byte-for-byte equivalent to passing the same archive
+    as a local file: same manifest, same hand-edited bodies, same plan.
+    """
+    src = tmp_path / "src"
+    bodies = _populated_firm_dir(src)
+    blob = pack(src, now=_PINNED_NOW)
+
+    url = "https://example.com/firm.zip"
+    route = respx.get(url).mock(
+        return_value=httpx.Response(200, content=blob)
+    )
+
+    plan = unpack(url)
+
+    # Exactly one GET, no retries, no probes.
+    assert route.call_count == 1
+    # Manifest and files match the local-path round trip.
+    assert plan.manifest["format_version"] == 1
+    assert plan.manifest["exported_at"] == "2026-01-01T00:00:00+00:00"
+    for name, expected in bodies.items():
+        assert plan.files[name].decode("utf-8") == expected
+
+
+@respx.mock
+def test_unpack_url_then_apply_round_trip(tmp_path: Path) -> None:
+    """End-to-end via URL: unpack from URL, then apply to a fresh firm dir
+    and assert every hand-edited body lands. Confirms the URL bytes path
+    feeds the same downstream apply machinery as the local-path branch."""
+    src = tmp_path / "src"
+    bodies = _populated_firm_dir(src)
+    blob = pack(src, now=_PINNED_NOW)
+
+    url = "https://example.com/firm.zip"
+    respx.get(url).mock(return_value=httpx.Response(200, content=blob))
+
+    plan = unpack(url)
+
+    dst = tmp_path / "dst"
+    dst.mkdir()
+    apply(plan, dst, ApplyMode.OVERWRITE)
+
+    for name, expected in bodies.items():
+        assert (dst / name).read_text(encoding="utf-8") == expected
+
+
+@respx.mock
+def test_unpack_url_non_2xx_raises_archive_error() -> None:
+    """A non-2xx HTTP response surfaces as :class:`ArchiveError` with a
+    clean message — the CLI's ``except ArchiveError`` branch must reach
+    the user without a stack trace."""
+    url = "https://example.com/firm.zip"
+    respx.get(url).mock(return_value=httpx.Response(404, text="not found"))
+
+    with pytest.raises(ArchiveError) as excinfo:
+        unpack(url)
+
+    msg = str(excinfo.value)
+    assert "404" in msg
+    assert url in msg
+
+
+@respx.mock
+def test_unpack_url_network_error_raises_archive_error() -> None:
+    """A transport-level failure (DNS, connection refused, etc.) is wrapped
+    as ArchiveError so the CLI surfaces it cleanly."""
+    url = "https://example.com/firm.zip"
+    respx.get(url).mock(side_effect=httpx.ConnectError("boom"))
+
+    with pytest.raises(ArchiveError) as excinfo:
+        unpack(url)
+
+    assert url in str(excinfo.value)
+
+
+@respx.mock
+def test_firm_import_cli_accepts_url(runner, tmp_path: Path) -> None:
+    """`wbox firm import <url> --yes` fetches the archive and writes the
+    firm directory just like the local-path form."""
+    from wealthbox_tools.cli._skill_paths import firm_dir
+
+    src = tmp_path / "src"
+    bodies = _populated_firm_dir(src)
+    blob = pack(src, now=_PINNED_NOW)
+
+    url = "https://example.com/firm.zip"
+    respx.get(url).mock(return_value=httpx.Response(200, content=blob))
+
+    fd = firm_dir()
+    fd.mkdir(parents=True, exist_ok=True)
+
+    result = runner.invoke(app, ["firm", "import", url, "--yes"])
+
+    assert result.exit_code == 0, (result.stdout or "") + (result.stderr or "")
+    for name, expected in bodies.items():
+        assert (fd / name).read_text(encoding="utf-8") == expected
+
+
+@respx.mock
+def test_firm_import_cli_url_non_2xx_surfaces_clean_error(
+    runner, tmp_path: Path
+) -> None:
+    """A non-2xx URL fetch shows the user a clean error, not a stack trace."""
+    url = "https://example.com/missing.zip"
+    respx.get(url).mock(return_value=httpx.Response(503, text="boom"))
+
+    result = runner.invoke(app, ["firm", "import", url, "--yes"])
+
+    assert result.exit_code != 0
+    combined = (result.stdout or "") + (result.stderr or "")
+    assert "Traceback" not in combined
+    assert "503" in combined


### PR DESCRIPTION
## Summary
- `unpack(source: Path | str)` now accepts an HTTP(S) URL string in addition to a local path; URL fetch is a single GET via httpx (no new transport dep) into bytes, then the same parsing path as local archives.
- `wbox firm import <PATH_OR_URL>` accepts both forms transparently — strings starting with `http://` / `https://` are fetched, anything else is a local path.
- Network errors and non-2xx responses are wrapped as `ArchiveError`, so the CLI's existing clean-error branch keeps working.

## Test plan
- [x] `ruff check src/ tests/` passes
- [x] `pytest -o pythonpath=src -q tests/test_firm_import.py` — 49 passed (6 new tests covering URL fetch, URL round-trip through apply, non-2xx response, network error, CLI URL form, CLI non-2xx clean error)
- [x] Full suite `pytest -o pythonpath=src -q` — 388 passed, 1 skipped (no regressions)

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)