### PR TITLE
feat: roll skill-ref auto-gen markers to remaining resources

### DIFF
--- a/src/wealthbox_tools/cli/internals.py
+++ b/src/wealthbox_tools/cli/internals.py
@@ -31,5 +31,7 @@ def regen_skill_refs() -> None:
         typer.echo(f"skipped (no markers) {path}", err=True)
     for path in result.missing:
         typer.echo(f"missing {path}", err=True)
+    for path in result.unmapped:
+        typer.echo(f"unmapped (no resource binding) {path}", err=True)
     if not result.modified:
         typer.echo("no changes")

--- a/src/wealthbox_tools/internals/skill_ref_gen.py
+++ b/src/wealthbox_tools/internals/skill_ref_gen.py
@@ -48,11 +48,15 @@ class ChangeSet:
     disk. ``skipped_no_markers`` lists paths that exist but lack the
     auto-gen markers (a warning was already printed to stderr). ``missing``
     lists paths that were expected but not found on disk.
+    ``unmapped`` lists reference markdown files found in the references
+    directory that do not appear in :data:`RESOURCE_REFERENCE_MAP` (a
+    warning was already printed to stderr).
     """
 
     modified: list[Path] = field(default_factory=list)
     skipped_no_markers: list[Path] = field(default_factory=list)
     missing: list[Path] = field(default_factory=list)
+    unmapped: list[Path] = field(default_factory=list)
 
 
 # ---------------------------------------------------------------------------
@@ -60,10 +64,22 @@ class ChangeSet:
 # ---------------------------------------------------------------------------
 
 #: Top-level Typer sub-app name → reference markdown filename (relative to
-#: the references directory). Slice #30 covers `contacts` only; subsequent
-#: issues will extend this map.
+#: the references directory). Slice #30 introduced the contract for
+#: ``contacts``; #35 rolled it across the remaining single-resource files.
+#:
+#: ``lookups.md`` is intentionally absent: it aggregates four resources
+#: (``me``, ``users``, ``activity``, ``categories``) and the marker contract
+#: is one block per file. The orphan scan in :func:`regenerate_all` warns
+#: about it on every run so the discrepancy stays visible.
 RESOURCE_REFERENCE_MAP: dict[str, str] = {
     "contacts": "contacts.md",
+    "events": "events.md",
+    "households": "households.md",
+    "notes": "notes.md",
+    "opportunities": "opportunities.md",
+    "projects": "projects.md",
+    "tasks": "tasks.md",
+    "workflows": "workflows.md",
 }
 
 
@@ -373,6 +389,23 @@ def regenerate_all(*, references_dir: Path | None = None) -> ChangeSet:
     """
     refs_dir = references_dir or _references_dir()
     changeset = ChangeSet()
+
+    # Warn once per run about reference markdown files that have no entry
+    # in RESOURCE_REFERENCE_MAP. These are aggregate or hand-curated docs
+    # (e.g. ``lookups.md``) that span multiple resources, so the one-block-
+    # per-file contract does not fit cleanly. Surfacing them keeps the
+    # discrepancy visible without silently regenerating empty files.
+    if refs_dir.exists():
+        mapped_filenames = set(RESOURCE_REFERENCE_MAP.values())
+        for md in sorted(refs_dir.glob("*.md")):
+            if md.name in mapped_filenames:
+                continue
+            print(
+                f"warning: skill-ref auto-gen has no mapping for {md}; "
+                "leaving file unchanged",
+                file=sys.stderr,
+            )
+            changeset.unmapped.append(md)
 
     # Sort for deterministic warning order.
     for resource in sorted(RESOURCE_REFERENCE_MAP):

--- a/src/wealthbox_tools/skills/wealthbox-crm/references/events.md
+++ b/src/wealthbox_tools/skills/wealthbox-crm/references/events.md
@@ -72,6 +72,159 @@ wbox events delete <ID>
 wbox events categories
 ```
 
+## Generated Flag Reference
+
+The following section is auto-generated from the Typer command tree by
+`wbox internals regen-skill-refs`. Do not hand-edit between the markers —
+edits will be overwritten on the next regen pass.
+
+<!-- auto-gen:flags -->
+### `wbox events add`
+
+Create a new event.
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--all-day` / `--no-all-day` | `BOOLEAN` | `-` |  |
+| `--category` | `INTEGER` | `-` | Event category ID |
+| `--contact` | `INTEGER` | `-` | Link to a Contact by ID |
+| `--description` | `TEXT` | `-` |  |
+| `--ends-at` | `TEXT` | `-` | End datetime in ISO 8601, e.g. 2026-01-15T11:00:00-07:00 |
+| `--format` | `CHOICE` | `json` |  |
+| `--location` | `TEXT` | `-` |  |
+| `--opportunity` | `INTEGER` | `-` | Link to an Opportunity by ID |
+| `--project` | `INTEGER` | `-` | Link to a Project by ID |
+| `--starts-at` | `TEXT` | `-` | Start datetime in ISO 8601, e.g. 2026-01-15T10:00:00-07:00 |
+| `--state` | `CHOICE` | `-` | unconfirmed, confirmed, tentative, completed, cancelled |
+
+**Choices for `--format`:**
+
+- `csv`
+- `json`
+- `table`
+- `tsv`
+
+**Choices for `--state`:**
+
+- `cancelled`
+- `completed`
+- `confirmed`
+- `tentative`
+- `unconfirmed`
+
+### `wbox events categories`
+
+List event category options.
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--format` | `CHOICE` | `json` |  |
+| `--page` | `INTEGER` | `-` | Page number |
+| `--per-page` | `INTEGER` | `-` | Results per page (max 100) |
+
+**Choices for `--format`:**
+
+- `csv`
+- `json`
+- `table`
+- `tsv`
+
+### `wbox events delete`
+
+Delete an existing event.
+
+_No flags._
+
+### `wbox events get`
+
+Get a single event by ID.
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--format` | `CHOICE` | `json` |  |
+| `--no-comments` | `BOOLEAN` | `false` | Omit comments from output |
+| `--verbose` / `-v` | `BOOLEAN` | `false` | Show all fields |
+
+**Choices for `--format`:**
+
+- `csv`
+- `json`
+- `table`
+- `tsv`
+
+### `wbox events list`
+
+List events with optional filters.
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--format` | `CHOICE` | `json` |  |
+| `--order` | `CHOICE` | `-` | Sort order: asc, desc, recent, created |
+| `--page` | `INTEGER` | `-` | Page number |
+| `--per-page` | `INTEGER` | `-` | Results per page (max 100) |
+| `--resource-id` | `INTEGER` | `-` | Filter by resource ID |
+| `--resource-type` | `CHOICE` | `-` | Supports: Contact, Project, Opportunity |
+| `--start-date-max` | `TEXT` | `-` | Format example: '2015-05-24 10:00 AM -0400' |
+| `--start-date-min` | `TEXT` | `-` | Format example: '2015-05-24 10:00 AM -0400' |
+| `--updated-before` | `TEXT` | `-` | Format example: '2015-05-24 10:00 AM -0400' |
+| `--updated-since` | `TEXT` | `-` | Format example: '2015-05-24 10:00 AM -0400' |
+| `--verbose` / `-v` | `BOOLEAN` | `false` | Show all fields |
+
+**Choices for `--format`:**
+
+- `csv`
+- `json`
+- `table`
+- `tsv`
+
+**Choices for `--order`:**
+
+- `asc`
+- `created`
+- `desc`
+- `recent`
+
+**Choices for `--resource-type`:**
+
+- `Contact`
+- `Opportunity`
+- `Project`
+
+### `wbox events update`
+
+Update an existing event. Pass only the fields you want to change.
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--all-day` / `--no-all-day` | `BOOLEAN` | `-` |  |
+| `--category` | `INTEGER` | `-` | Event category ID |
+| `--contact` | `INTEGER` | `-` | Replace linked Contact (by ID) |
+| `--description` | `TEXT` | `-` |  |
+| `--ends-at` | `TEXT` | `-` | End datetime in ISO 8601, e.g. 2026-01-15T11:00:00-07:00 |
+| `--format` | `CHOICE` | `json` |  |
+| `--location` | `TEXT` | `-` |  |
+| `--opportunity` | `INTEGER` | `-` | Replace linked Opportunity (by ID) |
+| `--project` | `INTEGER` | `-` | Replace linked Project (by ID) |
+| `--starts-at` | `TEXT` | `-` | Start datetime in ISO 8601, e.g. 2026-01-15T10:00:00-07:00 |
+| `--state` | `CHOICE` | `-` | unconfirmed, confirmed, tentative, completed, cancelled |
+| `--title` | `TEXT` | `-` | Event title |
+
+**Choices for `--format`:**
+
+- `csv`
+- `json`
+- `table`
+- `tsv`
+
+**Choices for `--state`:**
+
+- `cancelled`
+- `completed`
+- `confirmed`
+- `tentative`
+- `unconfirmed`
+<!-- /auto-gen:flags -->
+
 ## Examples
 
 ```bash

--- a/src/wealthbox_tools/skills/wealthbox-crm/references/households.md
+++ b/src/wealthbox_tools/skills/wealthbox-crm/references/households.md
@@ -27,6 +27,57 @@ wbox households remove-member <HOUSEHOLD_ID> <MEMBER_ID> [OPTIONS]
 | `<MEMBER_ID>` | positional | Person contact ID to remove (required) |
 | `--format` | json\|table\|csv\|tsv | Output format |
 
+## Generated Flag Reference
+
+The following section is auto-generated from the Typer command tree by
+`wbox internals regen-skill-refs`. Do not hand-edit between the markers —
+edits will be overwritten on the next regen pass.
+
+<!-- auto-gen:flags -->
+### `wbox households add-member`
+
+Add a member to a household. Usage: add-member <household_id> <member_id> --title <title>
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--format` | `CHOICE` | `json` |  |
+| `--title` | `CHOICE` | `-` | Household title for member (e.g. Spouse, Head) |
+
+**Choices for `--format`:**
+
+- `csv`
+- `json`
+- `table`
+- `tsv`
+
+**Choices for `--title`:**
+
+- `Child`
+- `Grandchild`
+- `Grandparent`
+- `Head`
+- `Other Dependent`
+- `Parent`
+- `Partner`
+- `Sibling`
+- `Spouse`
+
+### `wbox households remove-member`
+
+Remove a member from a household.
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--format` | `CHOICE` | `json` |  |
+
+**Choices for `--format`:**
+
+- `csv`
+- `json`
+- `table`
+- `tsv`
+<!-- /auto-gen:flags -->
+
 ## Examples
 
 ```bash

--- a/src/wealthbox_tools/skills/wealthbox-crm/references/notes.md
+++ b/src/wealthbox_tools/skills/wealthbox-crm/references/notes.md
@@ -56,6 +56,96 @@ wbox notes update <ID> [OPTIONS]
 | `--opportunity` | INT | Relink to opportunity |
 | `--format` | json\|table\|csv\|tsv | Output format |
 
+## Generated Flag Reference
+
+The following section is auto-generated from the Typer command tree by
+`wbox internals regen-skill-refs`. Do not hand-edit between the markers —
+edits will be overwritten on the next regen pass.
+
+<!-- auto-gen:flags -->
+### `wbox notes add`
+
+Create a new note.
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--contact` | `INTEGER` | `-` | Link to a Contact by ID |
+| `--format` | `CHOICE` | `json` |  |
+| `--opportunity` | `INTEGER` | `-` | Link to an Opportunity by ID |
+| `--project` | `INTEGER` | `-` | Link to a Project by ID |
+
+**Choices for `--format`:**
+
+- `csv`
+- `json`
+- `table`
+- `tsv`
+
+### `wbox notes get`
+
+Get a single note by ID.
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--format` | `CHOICE` | `json` |  |
+| `--no-comments` | `BOOLEAN` | `false` | Omit comments from output |
+| `--verbose` / `-v` | `BOOLEAN` | `false` | Show all fields |
+
+**Choices for `--format`:**
+
+- `csv`
+- `json`
+- `table`
+- `tsv`
+
+### `wbox notes list`
+
+List notes. Can filter by linked resource and/or updated date range.
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--contact` | `INTEGER` | `-` | Filter notes linked to a Contact (by ID) |
+| `--format` | `CHOICE` | `json` |  |
+| `--order` | `CHOICE` | `updated` | Sort order: updated or created |
+| `--page` | `INTEGER` | `-` |  |
+| `--per-page` | `INTEGER` | `-` | Results per page (max 100) |
+| `--updated-before` | `TEXT` | `-` |  |
+| `--updated-since` | `TEXT` | `-` |  |
+| `--verbose` / `-v` | `BOOLEAN` | `false` | Show all fields; content is not truncated |
+
+**Choices for `--format`:**
+
+- `csv`
+- `json`
+- `table`
+- `tsv`
+
+**Choices for `--order`:**
+
+- `asc`
+- `created`
+- `updated`
+
+### `wbox notes update`
+
+Update an existing note. Note: the API does not support deleting notes.
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--contact` | `INTEGER` | `-` | Replace linked Contact (by ID) |
+| `--content` | `TEXT` | `-` | New note body text |
+| `--format` | `CHOICE` | `json` |  |
+| `--opportunity` | `INTEGER` | `-` | Replace linked Opportunity (by ID) |
+| `--project` | `INTEGER` | `-` | Replace linked Project (by ID) |
+
+**Choices for `--format`:**
+
+- `csv`
+- `json`
+- `table`
+- `tsv`
+<!-- /auto-gen:flags -->
+
 ## Examples
 
 ```bash

--- a/src/wealthbox_tools/skills/wealthbox-crm/references/opportunities.md
+++ b/src/wealthbox_tools/skills/wealthbox-crm/references/opportunities.md
@@ -71,6 +71,131 @@ All create flags available. Only pass changed fields.
 wbox opportunities delete <ID>
 ```
 
+## Generated Flag Reference
+
+The following section is auto-generated from the Typer command tree by
+`wbox internals regen-skill-refs`. Do not hand-edit between the markers —
+edits will be overwritten on the next regen pass.
+
+<!-- auto-gen:flags -->
+### `wbox opportunities add`
+
+Create a new opportunity.
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--aum` | `FLOAT` | `-` | AUM amount |
+| `--commission` | `FLOAT` | `-` | Commission amount |
+| `--contact` | `INTEGER` | `-` | Link to a Contact by ID |
+| `--currency` | `TEXT` | `USD` | Currency code for all amounts (default: USD) |
+| `--description` | `TEXT` | `-` |  |
+| `--fee` | `FLOAT` | `-` | Fee amount |
+| `--format` | `CHOICE` | `json` |  |
+| `--manager` | `INTEGER` | `-` | Assign a manager by user ID |
+| `--more-fields` | `TEXT` | `-` | JSON object for additional fields (e.g. custom_fields) |
+| `--other-amount` | `FLOAT` | `-` | Other amount |
+| `--probability` | `INTEGER` | `-` | Close probability 0–100 |
+| `--project` | `INTEGER` | `-` | Link to a Project by ID |
+| `--stage` | `INTEGER` | `-` | Stage ID — see: wbox categories |
+| `--target-close` | `TEXT` | `-` | Target close date (e.g. 2026-06-30) |
+| `--visible-to` | `TEXT` | `-` |  |
+
+**Choices for `--format`:**
+
+- `csv`
+- `json`
+- `table`
+- `tsv`
+
+### `wbox opportunities delete`
+
+Delete an opportunity by ID.
+
+_No flags._
+
+### `wbox opportunities get`
+
+Get a single opportunity by ID.
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--format` | `CHOICE` | `json` |  |
+| `--no-comments` | `BOOLEAN` | `false` | Omit comments from output |
+
+**Choices for `--format`:**
+
+- `csv`
+- `json`
+- `table`
+- `tsv`
+
+### `wbox opportunities list`
+
+List opportunities with optional filters.
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--format` | `CHOICE` | `json` |  |
+| `--include-closed` / `--no-include-closed` | `BOOLEAN` | `-` | Include closed opportunities |
+| `--order` | `CHOICE` | `-` | Sort order: asc, desc, recent, created |
+| `--page` | `INTEGER` | `-` |  |
+| `--per-page` | `INTEGER` | `-` | Results per page (max 100) |
+| `--resource-id` | `INTEGER` | `-` | Filter by linked resource ID (requires --resource-type) |
+| `--resource-type` | `CHOICE` | `-` | Filter by linked resource type: Contact, Project |
+| `--updated-before` | `TEXT` | `-` |  |
+| `--updated-since` | `TEXT` | `-` |  |
+| `--verbose` / `-v` | `BOOLEAN` | `false` | Show all fields |
+
+**Choices for `--format`:**
+
+- `csv`
+- `json`
+- `table`
+- `tsv`
+
+**Choices for `--order`:**
+
+- `asc`
+- `created`
+- `desc`
+- `recent`
+
+**Choices for `--resource-type`:**
+
+- `Contact`
+- `Project`
+
+### `wbox opportunities update`
+
+Update an existing opportunity. Pass only the fields you want to change.
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--aum` | `FLOAT` | `-` | AUM amount |
+| `--commission` | `FLOAT` | `-` | Commission amount |
+| `--contact` | `INTEGER` | `-` | Replace linked Contact (by ID) |
+| `--currency` | `TEXT` | `USD` | Currency code for all amounts (default: USD) |
+| `--description` | `TEXT` | `-` |  |
+| `--fee` | `FLOAT` | `-` | Fee amount |
+| `--format` | `CHOICE` | `json` |  |
+| `--manager` | `INTEGER` | `-` |  |
+| `--more-fields` | `TEXT` | `-` | JSON object for additional fields (e.g. custom_fields) |
+| `--name` | `TEXT` | `-` |  |
+| `--other-amount` | `FLOAT` | `-` | Other amount |
+| `--probability` | `INTEGER` | `-` | Close probability 0–100 |
+| `--project` | `INTEGER` | `-` | Replace linked Project (by ID) |
+| `--stage` | `INTEGER` | `-` | Stage ID — see: wbox categories |
+| `--target-close` | `TEXT` | `-` |  |
+| `--visible-to` | `TEXT` | `-` |  |
+
+**Choices for `--format`:**
+
+- `csv`
+- `json`
+- `table`
+- `tsv`
+<!-- /auto-gen:flags -->
+
 ## Examples
 
 ```bash

--- a/src/wealthbox_tools/skills/wealthbox-crm/references/projects.md
+++ b/src/wealthbox_tools/skills/wealthbox-crm/references/projects.md
@@ -49,6 +49,89 @@ wbox projects update <ID> [OPTIONS]
 
 Flags: `--name`, `--description`, `--organizer`, `--visible-to`, `--more-fields`, `--format`.
 
+## Generated Flag Reference
+
+The following section is auto-generated from the Typer command tree by
+`wbox internals regen-skill-refs`. Do not hand-edit between the markers —
+edits will be overwritten on the next regen pass.
+
+<!-- auto-gen:flags -->
+### `wbox projects add`
+
+Create a new project.
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--description` | `TEXT` | `-` | Project description |
+| `--format` | `CHOICE` | `json` |  |
+| `--more-fields` | `TEXT` | `-` | JSON object for additional fields (e.g. custom_fields) |
+| `--organizer` | `INTEGER` | `-` | Organizer user ID |
+| `--visible-to` | `TEXT` | `-` |  |
+
+**Choices for `--format`:**
+
+- `csv`
+- `json`
+- `table`
+- `tsv`
+
+### `wbox projects get`
+
+Get a single project by ID.
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--format` | `CHOICE` | `json` |  |
+| `--no-comments` | `BOOLEAN` | `false` | Omit comments from output |
+
+**Choices for `--format`:**
+
+- `csv`
+- `json`
+- `table`
+- `tsv`
+
+### `wbox projects list`
+
+List projects with optional date range filters.
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--format` | `CHOICE` | `json` |  |
+| `--page` | `INTEGER` | `-` |  |
+| `--per-page` | `INTEGER` | `-` | Results per page (max 100) |
+| `--updated-before` | `TEXT` | `-` |  |
+| `--updated-since` | `TEXT` | `-` |  |
+| `--verbose` / `-v` | `BOOLEAN` | `false` | Show all fields |
+
+**Choices for `--format`:**
+
+- `csv`
+- `json`
+- `table`
+- `tsv`
+
+### `wbox projects update`
+
+Update an existing project. Pass only the fields you want to change.
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--description` | `TEXT` | `-` |  |
+| `--format` | `CHOICE` | `json` |  |
+| `--more-fields` | `TEXT` | `-` | JSON object for additional fields (e.g. custom_fields) |
+| `--name` | `TEXT` | `-` |  |
+| `--organizer` | `INTEGER` | `-` | Organizer user ID |
+| `--visible-to` | `TEXT` | `-` |  |
+
+**Choices for `--format`:**
+
+- `csv`
+- `json`
+- `table`
+- `tsv`
+<!-- /auto-gen:flags -->
+
 ## Examples
 
 ```bash

--- a/src/wealthbox_tools/skills/wealthbox-crm/references/tasks.md
+++ b/src/wealthbox_tools/skills/wealthbox-crm/references/tasks.md
@@ -92,6 +92,151 @@ wbox tasks delete <ID>
 wbox tasks categories
 ```
 
+## Generated Flag Reference
+
+The following section is auto-generated from the Typer command tree by
+`wbox internals regen-skill-refs`. Do not hand-edit between the markers —
+edits will be overwritten on the next regen pass.
+
+<!-- auto-gen:flags -->
+### `wbox tasks add`
+
+Create a new task. Required: name, and either due_date or frame.
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--assigned-to` | `INTEGER` | `-` | Assign to a user by ID |
+| `--category` | `TEXT` | `-` | Task category by name or ID — see: wbox categories task-categories |
+| `--contact` | `INTEGER` | `-` | Link to a Contact by ID |
+| `--description` | `TEXT` | `-` | Task description |
+| `--due-date` | `TEXT` | `-` | Example: '2025-05-24 10:00 AM -0700' (must match Wealthbox format) |
+| `--format` | `CHOICE` | `json` |  |
+| `--frame` | `_NORMALIZE_FRAME` | `-` | Friendly due timeframe. One of: today, tomorrow, this-week / this_week, next-week / next_week, future, specific. |
+| `--more-fields` | `TEXT` | `-` | JSON: {"complete": false, "assigned_to_team": 456} |
+| `--opportunity` | `INTEGER` | `-` | Link to an Opportunity by ID |
+| `--priority` | `CHOICE` | `-` | Low, Medium, or High |
+| `--project` | `INTEGER` | `-` | Link to a Project by ID |
+
+**Choices for `--format`:**
+
+- `csv`
+- `json`
+- `table`
+- `tsv`
+
+**Choices for `--priority`:**
+
+- `High`
+- `Low`
+- `Medium`
+
+### `wbox tasks categories`
+
+List task category options.
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--format` | `CHOICE` | `json` |  |
+| `--page` | `INTEGER` | `-` | Page number |
+| `--per-page` | `INTEGER` | `-` | Results per page (max 100) |
+
+**Choices for `--format`:**
+
+- `csv`
+- `json`
+- `table`
+- `tsv`
+
+### `wbox tasks delete`
+
+Delete a task by ID.
+
+_No flags._
+
+### `wbox tasks get`
+
+Get a single task by ID.
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--format` | `CHOICE` | `json` |  |
+| `--no-comments` | `BOOLEAN` | `false` | Omit comments from output |
+| `--verbose` / `-v` | `BOOLEAN` | `false` | Show all fields |
+
+**Choices for `--format`:**
+
+- `csv`
+- `json`
+- `table`
+- `tsv`
+
+### `wbox tasks list`
+
+List tasks with optional filters. By default only outstanding tasks are returned; use --include-completed to include completed tasks
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--assigned-to` | `INTEGER` | `-` | Filter by assigned user ID |
+| `--assigned-to-team` | `INTEGER` | `-` | Filter by assigned team ID |
+| `--contact` | `INTEGER` | `-` | Filter tasks linked to a Contact (by ID) |
+| `--created-by` | `INTEGER` | `-` | Filter by creator user ID |
+| `--format` | `CHOICE` | `json` |  |
+| `--include-completed` | `BOOLEAN` | `false` | Include completed tasks (default returns outstanding tasks only) |
+| `--opportunity` | `INTEGER` | `-` | Filter tasks linked to an Opportunity (by ID) |
+| `--page` | `INTEGER` | `-` |  |
+| `--per-page` | `INTEGER` | `-` | Results per page (max 100) |
+| `--project` | `INTEGER` | `-` | Filter tasks linked to a Project (by ID) |
+| `--type` | `CHOICE` | `-` | all, parents, subtasks |
+| `--updated-before` | `TEXT` | `-` |  |
+| `--updated-since` | `TEXT` | `-` |  |
+| `--verbose` / `-v` | `BOOLEAN` | `false` | Show all fields |
+
+**Choices for `--format`:**
+
+- `csv`
+- `json`
+- `table`
+- `tsv`
+
+**Choices for `--type`:**
+
+- `all`
+- `parents`
+- `subtasks`
+
+### `wbox tasks update`
+
+Update an existing task. Pass only the fields you want to change.
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--assigned-to` | `INTEGER` | `-` | Reassign to a user by ID |
+| `--category` | `TEXT` | `-` | Task category by name or ID — see: wbox categories task-categories |
+| `--complete` / `--no-complete` | `BOOLEAN` | `-` | Mark as complete or incomplete |
+| `--contact` | `INTEGER` | `-` | Replace linked Contact (by ID) |
+| `--description` | `TEXT` | `-` |  |
+| `--due-date` | `TEXT` | `-` | ISO 8601 datetime, e.g. '2026-04-01T09:00:00-07:00' |
+| `--format` | `CHOICE` | `json` |  |
+| `--frame` | `_NORMALIZE_FRAME` | `-` | Friendly due timeframe. One of: today, tomorrow, this-week / this_week, next-week / next_week, future, specific. |
+| `--name` | `TEXT` | `-` | Task name |
+| `--opportunity` | `INTEGER` | `-` | Replace linked Opportunity (by ID) |
+| `--priority` | `CHOICE` | `-` | Low, Medium, or High |
+| `--project` | `INTEGER` | `-` | Replace linked Project (by ID) |
+
+**Choices for `--format`:**
+
+- `csv`
+- `json`
+- `table`
+- `tsv`
+
+**Choices for `--priority`:**
+
+- `High`
+- `Low`
+- `Medium`
+<!-- /auto-gen:flags -->
+
 ## Examples
 
 ```bash

--- a/src/wealthbox_tools/skills/wealthbox-crm/references/workflows.md
+++ b/src/wealthbox_tools/skills/wealthbox-crm/references/workflows.md
@@ -95,6 +95,171 @@ wbox workflows templates list [OPTIONS]
 
 Same filter flags as workflow list.
 
+## Generated Flag Reference
+
+The following section is auto-generated from the Typer command tree by
+`wbox internals regen-skill-refs`. Do not hand-edit between the markers —
+edits will be overwritten on the next regen pass.
+
+<!-- auto-gen:flags -->
+### `wbox workflows add`
+
+Create a new workflow from a template.
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--contact` | `INTEGER` | `-` | Link to a Contact by ID |
+| `--format` | `CHOICE` | `json` |  |
+| `--label` | `TEXT` | `-` | Optional label for this workflow instance |
+| `--more-fields` | `TEXT` | `-` | JSON object for additional fields (e.g. workflow_milestones) |
+| `--opportunity` | `INTEGER` | `-` | Link to an Opportunity by ID |
+| `--project` | `INTEGER` | `-` | Link to a Project by ID |
+| `--starts-at` | `TEXT` | `-` | Start date (e.g. 2026-06-01) |
+| `--template` | `INTEGER` | `-` | Workflow template ID — see: wbox workflows templates list |
+| `--visible-to` | `TEXT` | `-` |  |
+
+**Choices for `--format`:**
+
+- `csv`
+- `json`
+- `table`
+- `tsv`
+
+### `wbox workflows complete-step`
+
+Mark a workflow step as complete.
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--due-date` | `TEXT` | `-` | Due date when restarting a step (requires --due-date-set) |
+| `--due-date-set` | `BOOLEAN` | `false` | Whether the restarted step has a due date |
+| `--format` | `CHOICE` | `json` |  |
+| `--no-advance-hint` | `BOOLEAN` | `false` | Skip the follow-up GET that summarizes the new active step (saves one API call). |
+| `--outcome-id` | `INTEGER` | `-` | Workflow outcome ID (if step has multiple outcomes) |
+
+**Choices for `--format`:**
+
+- `csv`
+- `json`
+- `table`
+- `tsv`
+
+### `wbox workflows get`
+
+Get a single workflow by ID.
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--format` | `CHOICE` | `json` |  |
+| `--no-comments` | `BOOLEAN` | `false` | Omit comments from output |
+| `--verbose` / `-v` | `BOOLEAN` | `false` | Show all fields including the full template |
+
+**Choices for `--format`:**
+
+- `csv`
+- `json`
+- `table`
+- `tsv`
+
+### `wbox workflows list`
+
+List workflows with optional filters.
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--format` | `CHOICE` | `json` |  |
+| `--page` | `INTEGER` | `-` |  |
+| `--per-page` | `INTEGER` | `-` | Results per page (max 100) |
+| `--resource-id` | `INTEGER` | `-` | Filter by linked resource ID (requires --resource-type) |
+| `--resource-type` | `CHOICE` | `-` | Filter by linked resource type: Contact, Project |
+| `--status` | `CHOICE` | `-` | active, completed, or scheduled |
+| `--updated-before` | `TEXT` | `-` |  |
+| `--updated-since` | `TEXT` | `-` |  |
+| `--verbose` / `-v` | `BOOLEAN` | `false` | Show all fields |
+
+**Choices for `--format`:**
+
+- `csv`
+- `json`
+- `table`
+- `tsv`
+
+**Choices for `--resource-type`:**
+
+- `Contact`
+- `Project`
+
+**Choices for `--status`:**
+
+- `active`
+- `completed`
+- `scheduled`
+
+### `wbox workflows next`
+
+Show the active step (or completion status) of a workflow.
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--format` | `CHOICE` | `json` |  |
+
+**Choices for `--format`:**
+
+- `csv`
+- `json`
+- `table`
+- `tsv`
+
+### `wbox workflows revert-step`
+
+Revert a completed workflow step.
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--format` | `CHOICE` | `json` |  |
+
+**Choices for `--format`:**
+
+- `csv`
+- `json`
+- `table`
+- `tsv`
+
+### `wbox workflows templates list`
+
+List available workflow templates.
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--format` | `CHOICE` | `json` |  |
+| `--page` | `INTEGER` | `-` |  |
+| `--per-page` | `INTEGER` | `-` | Results per page (max 100) |
+| `--resource-id` | `INTEGER` | `-` | Filter by linked resource ID |
+| `--resource-type` | `CHOICE` | `-` | Filter by linked resource type: Contact, Project |
+| `--status` | `CHOICE` | `-` | active, completed, or scheduled |
+| `--updated-before` | `TEXT` | `-` |  |
+| `--updated-since` | `TEXT` | `-` |  |
+| `--verbose` / `-v` | `BOOLEAN` | `false` | Show all fields |
+
+**Choices for `--format`:**
+
+- `csv`
+- `json`
+- `table`
+- `tsv`
+
+**Choices for `--resource-type`:**
+
+- `Contact`
+- `Project`
+
+**Choices for `--status`:**
+
+- `active`
+- `completed`
+- `scheduled`
+<!-- /auto-gen:flags -->
+
 ## Examples
 
 ```bash


### PR DESCRIPTION
## Summary

- Extended the `<!-- auto-gen:flags -->` contract from #30 to events, households, notes, opportunities, projects, tasks, and workflows. Each file now has a `## Generated Flag Reference` section with markers; the body between them is regenerated from the live Typer command tree by `wbox internals regen-skill-refs`.
- Added an orphan-scan pass to the generator: reference markdown files with no entry in `RESOURCE_REFERENCE_MAP` produce a one-line stderr warning. `lookups.md` aggregates four resources (me/users/activity/categories) and does not fit the one-block-per-file contract, so it is left unmapped on purpose and surfaces as an orphan warning every run. Generator change called out per the issue's "if necessary" guidance.

## Test plan

- [x] `python -m pytest -o "pythonpath=src" -q tests/test_skill_ref_gen.py` — 10 passed
- [x] Full suite: `python -m pytest -o "pythonpath=src" -q` — 382 passed, 1 skipped
- [x] `ruff check src/ tests/` — All checks passed
- [x] Two consecutive regen passes: first updates 7 files, second reports `no changes` (idempotent)
- [x] `git diff --exit-code -- src/wealthbox_tools/skills/wealthbox-crm/references/` after a fresh post-commit regen produces no diff

Closes #35