### PR TITLE
ci: skill-ref drift-detection job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,20 @@ jobs:
       - run: pip install -e ".[dev]"
       - run: pytest
 
-  publish:
+  skill-ref-drift:
     needs: [lint, test]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install -e ".[dev]"
+      - run: wbox internals regen-skill-refs
+      - run: git diff --exit-code -- src/wealthbox_tools/skills/wealthbox-crm/references/
+
+  publish:
+    needs: [lint, test, skill-ref-drift]
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary
- Adds a `skill-ref-drift` job to `.github/workflows/ci.yml` that runs `wbox internals regen-skill-refs` then `git diff --exit-code` on `src/wealthbox_tools/skills/wealthbox-crm/references/`
- Gates `publish` on the new job in addition to `lint` and `test`

This is the contributor-facing trip-wire that catches a forgotten regen step on a PR that adds or renames a flag.

Closes #44

## Test plan
- [ ] CI runs `lint`, `test`, and `skill-ref-drift` on this PR; all pass on a clean tree
- [ ] Manually verify the job fails if `references/` are stale (e.g., revert a regen on a feature branch)
- [ ] On a `v*` tag, `publish` only runs after all three jobs succeed