### PR TITLE
ci: fix docs deploy + bump Node 20 actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v6
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v8.1.0
         with:
           python-version: "3.12"
       - run: uv sync --extra dev
@@ -24,8 +24,8 @@ jobs:
       matrix:
         python-version: ["3.11", "3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v6
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v8.1.0
         with:
           python-version: ${{ matrix.python-version }}
       - run: uv sync --extra dev
@@ -35,8 +35,8 @@ jobs:
     needs: [lint, test]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v6
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v8.1.0
         with:
           python-version: "3.12"
       - run: uv sync --extra dev
@@ -51,8 +51,8 @@ jobs:
       id-token: write
     environment: pypi
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v6
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v8.1.0
         with:
           python-version: "3.12"
       - run: uv build

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,12 +18,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - run: pip install mkdocs-material
       - run: cp CONTRIBUTING.md docs/contributing.md
+      - run: cp CHANGELOG.md docs/changelog.md
       - run: mkdocs build --strict
       - uses: actions/upload-pages-artifact@v3
         with:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -59,6 +59,7 @@ nav:
   - Getting Started: getting-started.md
   - CLI Reference: cli-reference.md
   - Contributing: contributing.md
+  - Changelog: changelog.md
 
 extra:
   social:


### PR DESCRIPTION
## Summary

Two CI hygiene fixes bundled because they touch the same workflow files.

### 1. mkdocs docs-deploy was failing on every main push

`docs/index.md:72` links to `changelog.md`, but only `CHANGELOG.md` at the repo root exists. `mkdocs build --strict` aborts with `WARNING - Doc file ''index.md'' contains a link ''changelog.md'', but the target is not found among documentation files.` Same root cause on `4f52755` and `22728e8`.

Fix: stage `CHANGELOG.md` into `docs/changelog.md` at build time (mirrors the existing `CONTRIBUTING.md → docs/contributing.md` pattern) and add it to mkdocs nav.

### 2. Node.js 20 deprecation

GitHub removes Node 20 from runners on Sept 16 2026 and force-switches on June 2 2026. Bumping the flagged actions:

- `actions/checkout@v4` → `@v6` (Node 24 support)
- `astral-sh/setup-uv@v6` → `@v8.1.0` — pinned exact because [v8.0.0 removed rolling major/minor tags](https://github.com/astral-sh/setup-uv/releases/tag/v8.0.0) as a supply-chain mitigation (`@v8` no longer resolves)
- `actions/setup-python@v5` → `@v6` (Node 24 support)

## Test plan

- [x] `mkdocs build --strict` passes locally with `CHANGELOG.md` copied into `docs/`
- [ ] Post-merge: docs-deploy workflow goes green on main
- [ ] Post-merge: no more Node 20 deprecation annotations on CI runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)