### PR TITLE
ci: bump pages actions to v5 (Node 24)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,7 @@ jobs:
       - run: cp CONTRIBUTING.md docs/contributing.md
       - run: cp CHANGELOG.md docs/changelog.md
       - run: mkdocs build --strict
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: site/
 
@@ -38,4 +38,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Summary

Follow-up to #92. After bumping `actions/checkout`, `astral-sh/setup-uv`, and `actions/setup-python`, the Node 20 deprecation warning still fired for `actions/deploy-pages@v4` in the docs-deploy workflow. `actions/upload-pages-artifact@v3` is on the same runtime even though it wasn''t individually flagged this run.

Bumps both to `@v5` — release notes for `deploy-pages@v5.0.0` explicitly cite "Update Node.js version to 24.x".

## Test plan

- [ ] Post-merge: docs-deploy workflow goes green with zero Node 20 warnings on any action

🤖 Generated with [Claude Code](https://claude.com/claude-code)