### PR TITLE
v2.3.0: writable contact roles via --advisor-role

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wealthbox-cli"
-version = "2.2.1"
+version = "2.3.0"
 description = "CLI and client library for the Wealthbox CRM API"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/wealthbox_tools/cli/_util.py
+++ b/src/wealthbox_tools/cli/_util.py
@@ -451,6 +451,80 @@ async def resolve_category_id(
     raise typer.BadParameter(f"No {label} configured in this workspace.")
 
 
+def _match_contact_role(roles: list[dict[str, Any]], token: str) -> dict[str, Any]:
+    """Find a contact role by numeric id or case-insensitive name."""
+    if token.isdigit():
+        rid = int(token)
+        for r in roles:
+            if int(r.get("id", 0)) == rid:
+                return r
+        raise typer.BadParameter(f"No contact role with id {rid} in this workspace.")
+    target = token.casefold()
+    for r in roles:
+        if str(r.get("name", "")).casefold() == target:
+            return r
+    available = sorted(str(r["name"]) for r in roles if r.get("name"))
+    raise typer.BadParameter(
+        f"Unknown contact role '{token}'. Available: {', '.join(available) or '(none configured)'}"
+    )
+
+
+def _role_option_user(option: dict[str, Any]) -> dict[str, Any]:
+    return option.get("assigned_to") or {}
+
+
+def _match_role_option(role: dict[str, Any], token: str) -> int:
+    """Resolve a user (numeric id, exact name, or unique substring) to a role-option id."""
+    options = role.get("available_options", []) or []
+    role_name = role.get("name", "role")
+    if token.isdigit():
+        uid = int(token)
+        for opt in options:
+            if int(_role_option_user(opt).get("id", 0)) == uid:
+                return int(opt["id"])
+        raise typer.BadParameter(f"No user with id {uid} is available for role '{role_name}'.")
+    target = token.casefold()
+    exact = [o for o in options if str(_role_option_user(o).get("name", "")).casefold() == target]
+    matches = exact or [
+        o for o in options if target in str(_role_option_user(o).get("name", "")).casefold()
+    ]
+    if len(matches) == 1:
+        return int(matches[0]["id"])
+    if not matches:
+        names = sorted(str(_role_option_user(o).get("name", "")) for o in options)
+        raise typer.BadParameter(
+            f"No user matching '{token}' for role '{role_name}'. Available: {', '.join(names)}"
+        )
+    cand = sorted(str(_role_option_user(o).get("name", "")) for o in matches)
+    raise typer.BadParameter(
+        f"'{token}' is ambiguous for role '{role_name}': matches {', '.join(cand)}. Be more specific."
+    )
+
+
+async def resolve_contact_roles(client: WealthboxClient, specs: list[str]) -> list[dict[str, int]]:
+    """Resolve ``Role:User`` specs to ``[{"id": role_id, "value": option_id}]`` entries.
+
+    Role may be a contact-role name (case-insensitive) or numeric id. User may be a
+    user name (case-insensitive; exact preferred, else unique substring) or numeric
+    user id. Both are resolved against ``wbox contacts categories contact-roles`` —
+    the option id (``available_options[].id``), not the user id, is the value the
+    Wealthbox API stores.
+    """
+    data = await client.list_all_categories(CategoryType.CONTACT_ROLES)
+    roles = data.get("contact_roles", []) or []
+    resolved: list[dict[str, int]] = []
+    for spec in specs:
+        role_token, sep, user_token = spec.partition(":")
+        role_token, user_token = role_token.strip(), user_token.strip()
+        if not sep or not role_token or not user_token:
+            raise typer.BadParameter(
+                f"--advisor-role expects 'Role:User' (e.g. 'Associate Advisor:Greg Hyde'); got '{spec}'."
+            )
+        role = _match_contact_role(roles, role_token)
+        resolved.append({"id": int(role["id"]), "value": _match_role_option(role, user_token)})
+    return resolved
+
+
 def parse_more_fields(more_fields: str, reserved: set[str]) -> dict[str, Any]:
     """Parse --more-fields JSON and validate against reserved keys.
 

--- a/src/wealthbox_tools/cli/contacts.py
+++ b/src/wealthbox_tools/cli/contacts.py
@@ -25,7 +25,14 @@ from ._util import (
     make_resource_app,
     output_result,
     parse_more_fields,
+    resolve_contact_roles,
     run_client,
+)
+
+_ADVISOR_ROLE_HELP = (
+    "Assign a contact role as 'Role:User' (repeatable), e.g. "
+    "'Associate Advisor:Greg Hyde'. User may be a name or numeric user id. "
+    "Resolved via: wbox contacts categories contact-roles"
 )
 
 app = make_resource_app(help="Manage Wealthbox contacts.")
@@ -180,6 +187,23 @@ def _build_contact_entry(value: str | None, kind: str | None) -> list[dict[str, 
     return [entry]
 
 
+def _finish_create(
+    payload: dict[str, Any], advisor_role: list[str] | None, token: str | None, fmt: OutputFormat
+) -> None:
+    """Resolve any --advisor-role specs in-session, build the model, create, and print."""
+    if advisor_role and "contact_roles" in payload:
+        raise typer.BadParameter(
+            "Set contact roles via --advisor-role OR contact_roles in --more-fields, not both."
+        )
+
+    async def _do(client: Any) -> Any:
+        if advisor_role:
+            payload["contact_roles"] = await resolve_contact_roles(client, advisor_role)
+        return await client.create_contact(ContactCreateInput(**payload))
+
+    output_result(run_client(token, _do), fmt)
+
+
 def _create_named_contact(
     record_type: RecordType,
     reserved: set[str],
@@ -194,6 +218,7 @@ def _create_named_contact(
     phone_type: str | None,
     tags: str | None,
     more_fields: str | None,
+    advisor_role: list[str] | None,
     token: str | None,
     fmt: OutputFormat,
 ) -> None:
@@ -216,8 +241,7 @@ def _create_named_contact(
         payload["tags"] = tag_list
     if more_fields:
         payload.update(parse_more_fields(more_fields, reserved))
-    input_model = ContactCreateInput(**payload)
-    output_result(run_client(token, lambda c: c.create_contact(input_model)), fmt)
+    _finish_create(payload, advisor_role, token, fmt)
 
 
 @add_app.command("person", help="Create a Person contact.")
@@ -253,6 +277,7 @@ def add_person(
     more_fields: str | None = typer.Option(
         None, "--more-fields", help="Extra fields as JSON object (merged with flags; cannot override explicit flags)"
     ),
+    advisor_role: list[str] | None = typer.Option(None, "--advisor-role", help=_ADVISOR_ROLE_HELP),
     token: str | None = typer.Option(None, envvar="WEALTHBOX_TOKEN", hidden=True),
     fmt: OutputFormat = typer.Option(OutputFormat.JSON, "--format"),
 ) -> None:
@@ -286,8 +311,7 @@ def add_person(
         payload["tags"] = tag_list
     if more_fields:
         payload.update(parse_more_fields(more_fields, _PERSON_RESERVED))
-    input_model = ContactCreateInput(**payload)
-    output_result(run_client(token, lambda c: c.create_contact(input_model)), fmt)
+    _finish_create(payload, advisor_role, token, fmt)
 
 
 @add_app.command("household", help="Create a Household contact.")
@@ -308,6 +332,7 @@ def add_household(
     more_fields: str | None = typer.Option(
         None, "--more-fields", help="Extra fields as JSON object (merged with flags; cannot override explicit flags)"
     ),
+    advisor_role: list[str] | None = typer.Option(None, "--advisor-role", help=_ADVISOR_ROLE_HELP),
     token: str | None = typer.Option(None, envvar="WEALTHBOX_TOKEN", hidden=True),
     fmt: OutputFormat = typer.Option(OutputFormat.JSON, "--format"),
 ) -> None:
@@ -327,8 +352,7 @@ def add_household(
         payload["tags"] = tag_list
     if more_fields:
         payload.update(parse_more_fields(more_fields, _HOUSEHOLD_RESERVED))
-    input_model = ContactCreateInput(**payload)
-    output_result(run_client(token, lambda c: c.create_contact(input_model)), fmt)
+    _finish_create(payload, advisor_role, token, fmt)
 
 
 @add_app.command("org", help="Create an Organization contact.")
@@ -353,12 +377,13 @@ def add_org(
     more_fields: str | None = typer.Option(
         None, "--more-fields", help="Extra fields as JSON object (merged with flags; cannot override explicit flags)"
     ),
+    advisor_role: list[str] | None = typer.Option(None, "--advisor-role", help=_ADVISOR_ROLE_HELP),
     token: str | None = typer.Option(None, envvar="WEALTHBOX_TOKEN", hidden=True),
     fmt: OutputFormat = typer.Option(OutputFormat.JSON, "--format"),
 ) -> None:
     _create_named_contact(
         RecordType.ORGANIZATION, _ORG_TRUST_RESERVED, name, contact_type, contact_source,
-        active, assigned_to, email, email_type, phone, phone_type, tags, more_fields, token, fmt,
+        active, assigned_to, email, email_type, phone, phone_type, tags, more_fields, advisor_role, token, fmt,
     )
 
 
@@ -384,12 +409,13 @@ def add_trust(
     more_fields: str | None = typer.Option(
         None, "--more-fields", help="Extra fields as JSON object (merged with flags; cannot override explicit flags)"
     ),
+    advisor_role: list[str] | None = typer.Option(None, "--advisor-role", help=_ADVISOR_ROLE_HELP),
     token: str | None = typer.Option(None, envvar="WEALTHBOX_TOKEN", hidden=True),
     fmt: OutputFormat = typer.Option(OutputFormat.JSON, "--format"),
 ) -> None:
     _create_named_contact(
         RecordType.TRUST, _ORG_TRUST_RESERVED, name, contact_type, contact_source,
-        active, assigned_to, email, email_type, phone, phone_type, tags, more_fields, token, fmt,
+        active, assigned_to, email, email_type, phone, phone_type, tags, more_fields, advisor_role, token, fmt,
     )
 
 
@@ -420,13 +446,19 @@ def update_contact(
             "include existing tags you wish to keep. New tags are auto-created."
         ),
     ),
+    advisor_role: list[str] | None = typer.Option(None, "--advisor-role", help=_ADVISOR_ROLE_HELP),
     token: str | None = typer.Option(None, envvar="WEALTHBOX_TOKEN", hidden=True),
     fmt: OutputFormat = typer.Option(OutputFormat.JSON, "--format"),
 ) -> None:
+    if advisor_role and json_data is not None:
+        raise typer.BadParameter(
+            "Set contact roles via --advisor-role OR contact_roles in --json, not both."
+        )
+
     if json_data is not None:
-        input_model = ContactUpdateInput(**json.loads(json_data))
+        payload: dict[str, Any] = json.loads(json_data)
     else:
-        payload: dict[str, Any] = {k: v for k, v in {
+        payload = {k: v for k, v in {
             "first_name": first_name,
             "middle_name": middle_name,
             "last_name": last_name,
@@ -441,9 +473,13 @@ def update_contact(
         tag_list = _parse_tags(tags)
         if tag_list is not None:
             payload["tags"] = tag_list
-        input_model = ContactUpdateInput(**payload)
 
-    output_result(run_client(token, lambda c: c.update_contact(contact_id, input_model)), fmt)
+    async def _do(client: Any) -> Any:
+        if advisor_role:
+            payload["contact_roles"] = await resolve_contact_roles(client, advisor_role)
+        return await client.update_contact(contact_id, ContactUpdateInput(**payload))
+
+    output_result(run_client(token, _do), fmt)
 
 
 @app.command("delete", help="Delete an existing contact.")

--- a/src/wealthbox_tools/models/common.py
+++ b/src/wealthbox_tools/models/common.py
@@ -105,8 +105,16 @@ class StreetAddress(WealthboxModel):
 
 
 class ContactRoleAssignment(WealthboxModel):
-    id: int | None = Field(default=None, ge=1)
-    type: str | None = None
+    """A contact-role assignment on a contact's write payload.
+
+    ``id`` is the contact-role id (e.g. "Associate Advisor") and ``value`` is
+    the *role-option* id that maps to a specific user — NOT the user's id.
+    Resolve both from ``wbox contacts categories contact-roles``, whose
+    ``available_options[].id`` is the value to use here.
+    """
+
+    id: int = Field(ge=1, description="Contact-role id (from contacts categories contact-roles)")
+    value: int = Field(ge=1, description="Role-option id mapping to a user (available_options[].id)")
 
 
 class LinkedToRef(WealthboxModel):

--- a/src/wealthbox_tools/skills/wealthbox-crm/SKILL.md
+++ b/src/wealthbox_tools/skills/wealthbox-crm/SKILL.md
@@ -195,3 +195,5 @@ The single-quoted heredoc (`<<'EOF'`) is the recommended default — it disables
 - **Relative due dates:** tasks accept `--frame today|tomorrow|this-week|next-week|this-month|next-month` instead of `--due-date` (mutually exclusive)
 - **Activity pagination:** uses `--cursor`, not `--page`
 - **Don't infer flag names:** read `references/<resource>.md` before invoking — flags like `--name` (not `--search`), `--frame` (not `--due-in`) are easy to guess wrong
+- **Advisor / contact roles:** assign them with `wbox contacts add|update ... --advisor-role "Role:User"` (e.g. `"Associate Advisor:Greg Hyde"`). This covers a firm's "Second Advisor" / Partner assignments. See `references/contacts.md` → "Contact Roles".
+- **Before falling back to raw API, exhaust the CLI:** if a firm-required field has no obvious flag, check `references/<resource>.md`, run `wbox <resource> --help` / `wbox <resource> <sub> --help`, and look for a `wbox <resource> categories <type>` lookup that supplies the needed ids. Reach for raw `curl`/API only after these come up empty — and if they do, that's a CLI gap worth filing as an issue.

--- a/src/wealthbox_tools/skills/wealthbox-crm/firm-examples/contacts.md
+++ b/src/wealthbox_tools/skills/wealthbox-crm/firm-examples/contacts.md
@@ -1,12 +1,24 @@
 # firm/contacts.md — Example
 
+This is an illustrative template. Replace every value below with your firm's
+real conventions. Valid category values (contact types, sources, roles, etc.)
+come from your workspace — list them with `wbox contacts categories <type>`.
+
 ## Required Fields
-- contact-type: always one of: Client, Prospect, Center of Influence, Vendor
-- contact-source: always one of: Referral, Website, Event, Cold Call
+- contact-type: one of your workspace's contact types (`wbox contacts categories contact-types`)
+- contact-source: one of your workspace's sources (`wbox contacts categories contact-sources`)
 
 ## Defaults
-- assigned-to: 12345
+- assigned-to: <your default user id> (`wbox me user-id`)
 - active: true
+
+## Advisor / Contact Roles
+- If your firm assigns advisors via contact roles (e.g. "Associate Advisor",
+  "Partner"), set them with `--advisor-role "Role:User"` on add/update.
+- List the configured roles and their assignable users with
+  `wbox contacts categories contact-roles`.
+- Example: a prospect's primary advisor is `--assigned-to`, and the second
+  advisor is `--advisor-role "Associate Advisor:<user>"`.
 
 ## Person Contacts
 - Always collect: email, phone, birth-date
@@ -15,7 +27,8 @@
 
 ## Household Contacts
 - Always create a household when onboarding a married couple
-- Naming convention: "The {LastName} Family"
+- Naming convention: e.g. "{Last}, {Head First} & {Spouse First}"
+- Add members one at a time (sequential) — see references/households.md
 
 ## Organization / Trust Contacts
-- Require EIN in more-fields for Trusts
+- Require EIN in --more-fields for Trusts

--- a/src/wealthbox_tools/skills/wealthbox-crm/references/contacts.md
+++ b/src/wealthbox_tools/skills/wealthbox-crm/references/contacts.md
@@ -70,6 +70,7 @@ wbox contacts add person [OPTIONS]
 | `--phone` | STR | Phone number |
 | `--phone-type` | STR | Work, Mobile, etc. |
 | `--tags` | STR | Comma-separated tag names (e.g. "VIP,Q1-Outreach"). New tags are auto-created. |
+| `--advisor-role` | STR | Assign a contact role (repeatable): `"Role:User"`, e.g. `"Associate Advisor:Greg Hyde"`. See "Contact Roles" below. |
 | `--more-fields` | JSON | Additional fields as JSON object |
 | `--format` | json\|table\|csv\|tsv | Output format |
 
@@ -77,7 +78,7 @@ wbox contacts add person [OPTIONS]
 ```bash
 wbox contacts add household --name <NAME> [OPTIONS]
 ```
-`--name` is required. Supports: `--contact-type`, `--contact-source`, `--active/--inactive`, `--assigned-to`, `--email`, `--email-type`, `--tags`, `--more-fields`, `--format`.
+`--name` is required. Supports: `--contact-type`, `--contact-source`, `--active/--inactive`, `--assigned-to`, `--email`, `--email-type`, `--tags`, `--advisor-role`, `--more-fields`, `--format`.
 
 ### Organization
 ```bash
@@ -112,6 +113,7 @@ Only pass the fields you want to change:
 | `--active` / `--inactive` | flag | Active status |
 | `--assigned-to` | INT | Reassign to user ID |
 | `--tags` | STR | Comma-separated tag names. Replaces all tags — include existing ones to keep. |
+| `--advisor-role` | STR | Assign a contact role (repeatable): `"Role:User"`. See "Contact Roles" below. Mutually exclusive with a `contact_roles` block in `--json`. |
 | `--json` | STR | Full JSON for nested/complex fields |
 | `--format` | json\|table\|csv\|tsv | Output format |
 
@@ -136,6 +138,51 @@ wbox contacts categories website-types
 wbox contacts categories contact-roles
 ```
 
+## Contact Roles (advisor assignments)
+
+Contact roles attach a user to a contact in a named role — e.g. **Associate
+Advisor** ("Second Advisor") or **Partner**. This is how firm advisor
+assignments are stored; they are *separate* from `--assigned-to` (the primary
+owner).
+
+**Use the `--advisor-role` flag** (repeatable) on `add person|household|org|trust`
+and on `update`:
+
+```bash
+wbox contacts add person --first-name Mark --last-name Leone \
+  --advisor-role "Associate Advisor:Greg Hyde" \
+  --advisor-role "Partner:Jane Smith"
+
+wbox contacts update 12345 --advisor-role "Associate Advisor:Greg Hyde"
+```
+
+The spec is `Role:User`. The role is matched by name (case-insensitive) or
+numeric id; the user by name (exact, else unique substring) or numeric user id.
+The flag resolves both against `wbox contacts categories contact-roles` for you.
+
+**The underlying write shape** (if you ever build it by hand via `--more-fields`
+or `--json`) is `{"id": <role_id>, "value": <option_id>}`:
+
+```bash
+wbox contacts update 12345 --json '{"contact_roles": [{"id": 1338, "value": 4226}]}'
+```
+
+⚠️ `value` is the **role-option id**, NOT the user id. Each role exposes
+`available_options[].id`, one per assignable user — that option id is the value.
+Look it up with `wbox contacts categories contact-roles`:
+
+```jsonc
+{ "id": 1338, "name": "Associate Advisor",
+  "available_options": [
+    { "id": 4226, "assigned_to": { "id": 154372, "name": "Greg Hyde" } }
+  ] }
+// → to set Greg as Associate Advisor: {"id": 1338, "value": 4226}
+```
+
+Notes: roles can only be added/updated, not removed, via the API. You only need
+to include the roles you're changing. `--advisor-role` and a `contact_roles`
+block in `--more-fields`/`--json` are mutually exclusive.
+
 ## Generated Flag Reference
 
 The following section is auto-generated from the Typer command tree by
@@ -150,6 +197,7 @@ Create a Household contact.
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--active` / `--inactive` | `BOOLEAN` | `-` | Set contact status to Active or Inactive |
+| `--advisor-role` | `TEXT` | `-` | Assign a contact role as 'Role:User' (repeatable), e.g. 'Associate Advisor:Greg Hyde'. User may be a name or numeric user id. Resolved via: wbox contacts categories contact-roles |
 | `--assigned-to` | `INTEGER` | `-` | Assign to a user by ID |
 | `--contact-source` | `TEXT` | `-` |  |
 | `--contact-type` | `TEXT` | `-` | e.g. Client, Prospect |
@@ -174,6 +222,7 @@ Create an Organization contact.
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--active` / `--inactive` | `BOOLEAN` | `-` | Set contact status to Active or Inactive |
+| `--advisor-role` | `TEXT` | `-` | Assign a contact role as 'Role:User' (repeatable), e.g. 'Associate Advisor:Greg Hyde'. User may be a name or numeric user id. Resolved via: wbox contacts categories contact-roles |
 | `--assigned-to` | `INTEGER` | `-` | Assign to a user by ID |
 | `--contact-source` | `TEXT` | `-` |  |
 | `--contact-type` | `TEXT` | `-` | e.g. Client, Prospect |
@@ -200,6 +249,7 @@ Create a Person contact.
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--active` / `--inactive` | `BOOLEAN` | `-` | Set contact status to Active or Inactive |
+| `--advisor-role` | `TEXT` | `-` | Assign a contact role as 'Role:User' (repeatable), e.g. 'Associate Advisor:Greg Hyde'. User may be a name or numeric user id. Resolved via: wbox contacts categories contact-roles |
 | `--anniversary` | `TEXT` | `-` | Format: YYYY-MM-DD |
 | `--assigned-to` | `INTEGER` | `-` | Assign to a user by ID |
 | `--birth-date` | `TEXT` | `-` | Format: YYYY-MM-DD |
@@ -254,6 +304,7 @@ Create a Trust contact.
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--active` / `--inactive` | `BOOLEAN` | `-` | Set contact status to Active or Inactive |
+| `--advisor-role` | `TEXT` | `-` | Assign a contact role as 'Role:User' (repeatable), e.g. 'Associate Advisor:Greg Hyde'. User may be a name or numeric user id. Resolved via: wbox contacts categories contact-roles |
 | `--assigned-to` | `INTEGER` | `-` | Assign to a user by ID |
 | `--contact-source` | `TEXT` | `-` |  |
 | `--contact-type` | `TEXT` | `-` | e.g. Client, Prospect |
@@ -479,6 +530,7 @@ Update an existing contact. Pass only the fields you want to change.
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--active` / `--inactive` | `BOOLEAN` | `-` | Set contact status to Active or Inactive |
+| `--advisor-role` | `TEXT` | `-` | Assign a contact role as 'Role:User' (repeatable), e.g. 'Associate Advisor:Greg Hyde'. User may be a name or numeric user id. Resolved via: wbox contacts categories contact-roles |
 | `--assigned-to` | `INTEGER` | `-` | Reassign to a user by ID |
 | `--company-name` | `TEXT` | `-` |  |
 | `--contact-source` | `TEXT` | `-` |  |
@@ -512,7 +564,12 @@ wbox contacts add person --first-name Jane --last-name Doe --contact-type Client
 # Update job title
 wbox contacts update 12345 --job-title "CFO"
 
-# Create a household and add members (two-step)
+# Create a prospect with primary owner + advisor role in one call
+wbox contacts add person --first-name Jane --last-name Doe \
+  --contact-type Prospect --assigned-to 154372 \
+  --advisor-role "Associate Advisor:Greg Hyde"
+
+# Create a household and add members (two-step — add members SEQUENTIALLY)
 wbox contacts add household --name "The Smith Family"
 # note the returned ID, then:
 wbox households add-member <HOUSEHOLD_ID> <MEMBER_ID> --title Head

--- a/src/wealthbox_tools/skills/wealthbox-crm/references/households.md
+++ b/src/wealthbox_tools/skills/wealthbox-crm/references/households.md
@@ -2,6 +2,11 @@
 
 Manage membership of household contacts. Household contacts are created via `wbox contacts add household`.
 
+> ⚠️ **Add members one at a time, sequentially.** Each `add-member` call
+> rewrites the household's member list, so concurrent/parallel calls race and
+> the last write clobbers the earlier ones. Run them in series and wait for
+> each to return before issuing the next.
+
 ## Add Member
 
 ```bash

--- a/tests/test_contact_roles.py
+++ b/tests/test_contact_roles.py
@@ -1,0 +1,233 @@
+"""Tests for contact-role assignment: the {id, value} model shape and the
+--advisor-role flag that resolves 'Role:User' specs to role+option ids."""
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+import respx
+from pydantic import ValidationError
+
+from wealthbox_tools.cli.main import app
+from wealthbox_tools.models import ContactCreateInput, ContactUpdateInput
+
+_CONTACTS_URL = "https://api.crmworkspace.com/v1/contacts"
+_ROLES_URL = "https://api.crmworkspace.com/v1/categories/contact_roles"
+_CONTACT_RESPONSE = {"id": 1, "name": "John Doe", "type": "Person"}
+
+# Mirrors the live `categories contact_roles` shape: each role carries
+# available_options whose `id` (NOT the user id) is what the API stores.
+_ROLES_RESPONSE = {
+    "contact_roles": [
+        {
+            "id": 1338,
+            "name": "Associate Advisor",
+            "available_options": [
+                {"id": 3465, "assigned_to": {"id": 152760, "type": "User", "name": "Kadin Bullock"}},
+                {"id": 4226, "assigned_to": {"id": 154372, "type": "User", "name": "Greg Hyde"}},
+            ],
+        },
+        {
+            "id": 2727,
+            "name": "Partner",
+            "available_options": [
+                {"id": 7651, "assigned_to": {"id": 154372, "type": "User", "name": "Greg Hyde"}},
+            ],
+        },
+    ]
+}
+
+
+# ---------------------------------------------------------------------------
+# model: the write shape is {id, value}, both required positive ints
+# ---------------------------------------------------------------------------
+
+def test_model_accepts_id_value() -> None:
+    m = ContactCreateInput(type="Person", first_name="X", contact_roles=[{"id": 1338, "value": 3465}])
+    assert m.model_dump(exclude_none=True)["contact_roles"] == [{"id": 1338, "value": 3465}]
+
+
+def test_model_update_accepts_id_value() -> None:
+    u = ContactUpdateInput(contact_roles=[{"id": 2727, "value": 4226}])
+    assert u.model_dump(exclude_unset=True)["contact_roles"] == [{"id": 2727, "value": 4226}]
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        {"id": 1338},  # missing value
+        {"value": 3465},  # missing id
+        {"id": 1338, "value": 3465, "type": "User"},  # stale read-shape extra
+        {"id": 1338, "value": 0},  # value must be >= 1
+    ],
+)
+def test_model_rejects_bad_role_shapes(bad: dict) -> None:  # type: ignore[type-arg]
+    with pytest.raises(ValidationError):
+        ContactCreateInput(type="Person", contact_roles=[bad])
+
+
+# ---------------------------------------------------------------------------
+# --advisor-role on create
+# ---------------------------------------------------------------------------
+
+@respx.mock
+def test_add_person_advisor_role_by_name(runner) -> None:
+    respx.get(_ROLES_URL).mock(return_value=httpx.Response(200, json=_ROLES_RESPONSE))
+    route = respx.post(_CONTACTS_URL).mock(return_value=httpx.Response(200, json=_CONTACT_RESPONSE))
+    result = runner.invoke(
+        app,
+        ["contacts", "add", "person", "--first-name", "John",
+         "--advisor-role", "Associate Advisor:Kadin Bullock"],
+    )
+    assert result.exit_code == 0, result.output
+    sent = json.loads(route.calls[0].request.content)
+    assert sent["contact_roles"] == [{"id": 1338, "value": 3465}]
+
+
+@respx.mock
+def test_add_person_advisor_role_by_user_id(runner) -> None:
+    respx.get(_ROLES_URL).mock(return_value=httpx.Response(200, json=_ROLES_RESPONSE))
+    route = respx.post(_CONTACTS_URL).mock(return_value=httpx.Response(200, json=_CONTACT_RESPONSE))
+    result = runner.invoke(
+        app,
+        ["contacts", "add", "person", "--first-name", "John",
+         "--advisor-role", "Associate Advisor:154372"],
+    )
+    assert result.exit_code == 0, result.output
+    sent = json.loads(route.calls[0].request.content)
+    assert sent["contact_roles"] == [{"id": 1338, "value": 4226}]
+
+
+@respx.mock
+def test_add_person_advisor_role_substring_match(runner) -> None:
+    respx.get(_ROLES_URL).mock(return_value=httpx.Response(200, json=_ROLES_RESPONSE))
+    route = respx.post(_CONTACTS_URL).mock(return_value=httpx.Response(200, json=_CONTACT_RESPONSE))
+    result = runner.invoke(
+        app,
+        ["contacts", "add", "person", "--first-name", "John", "--advisor-role", "Partner:Greg"],
+    )
+    assert result.exit_code == 0, result.output
+    sent = json.loads(route.calls[0].request.content)
+    assert sent["contact_roles"] == [{"id": 2727, "value": 7651}]
+
+
+@respx.mock
+def test_add_person_multiple_advisor_roles(runner) -> None:
+    respx.get(_ROLES_URL).mock(return_value=httpx.Response(200, json=_ROLES_RESPONSE))
+    route = respx.post(_CONTACTS_URL).mock(return_value=httpx.Response(200, json=_CONTACT_RESPONSE))
+    result = runner.invoke(
+        app,
+        ["contacts", "add", "person", "--first-name", "John",
+         "--advisor-role", "Associate Advisor:Kadin Bullock",
+         "--advisor-role", "Partner:Greg Hyde"],
+    )
+    assert result.exit_code == 0, result.output
+    sent = json.loads(route.calls[0].request.content)
+    assert sent["contact_roles"] == [{"id": 1338, "value": 3465}, {"id": 2727, "value": 7651}]
+
+
+@respx.mock
+def test_add_household_advisor_role(runner) -> None:
+    respx.get(_ROLES_URL).mock(return_value=httpx.Response(200, json=_ROLES_RESPONSE))
+    route = respx.post(_CONTACTS_URL).mock(
+        return_value=httpx.Response(200, json={"id": 2, "name": "The Smiths", "type": "Household"})
+    )
+    result = runner.invoke(
+        app,
+        ["contacts", "add", "household", "--name", "The Smiths",
+         "--advisor-role", "Associate Advisor:Greg Hyde"],
+    )
+    assert result.exit_code == 0, result.output
+    sent = json.loads(route.calls[0].request.content)
+    assert sent["contact_roles"] == [{"id": 1338, "value": 4226}]
+
+
+@respx.mock
+def test_add_org_advisor_role(runner) -> None:
+    respx.get(_ROLES_URL).mock(return_value=httpx.Response(200, json=_ROLES_RESPONSE))
+    route = respx.post(_CONTACTS_URL).mock(
+        return_value=httpx.Response(200, json={"id": 3, "name": "Acme", "type": "Organization"})
+    )
+    result = runner.invoke(
+        app,
+        ["contacts", "add", "org", "--name", "Acme", "--advisor-role", "Partner:Greg Hyde"],
+    )
+    assert result.exit_code == 0, result.output
+    sent = json.loads(route.calls[0].request.content)
+    assert sent["contact_roles"] == [{"id": 2727, "value": 7651}]
+
+
+# ---------------------------------------------------------------------------
+# --advisor-role error handling
+# ---------------------------------------------------------------------------
+
+@respx.mock
+def test_advisor_role_unknown_role_fails_without_post(runner) -> None:
+    respx.get(_ROLES_URL).mock(return_value=httpx.Response(200, json=_ROLES_RESPONSE))
+    route = respx.post(_CONTACTS_URL).mock(return_value=httpx.Response(200, json=_CONTACT_RESPONSE))
+    result = runner.invoke(
+        app,
+        ["contacts", "add", "person", "--first-name", "John", "--advisor-role", "Bogus Role:Greg Hyde"],
+    )
+    assert result.exit_code != 0
+    assert not route.called
+
+
+@respx.mock
+def test_advisor_role_unknown_user_fails(runner) -> None:
+    respx.get(_ROLES_URL).mock(return_value=httpx.Response(200, json=_ROLES_RESPONSE))
+    respx.post(_CONTACTS_URL).mock(return_value=httpx.Response(200, json=_CONTACT_RESPONSE))
+    result = runner.invoke(
+        app,
+        ["contacts", "add", "person", "--first-name", "John",
+         "--advisor-role", "Associate Advisor:Nobody"],
+    )
+    assert result.exit_code != 0
+
+
+def test_advisor_role_bad_format_fails(runner) -> None:
+    result = runner.invoke(
+        app,
+        ["contacts", "add", "person", "--first-name", "John", "--advisor-role", "no-colon-here"],
+    )
+    assert result.exit_code != 0
+
+
+def test_advisor_role_collides_with_more_fields(runner) -> None:
+    extra = json.dumps({"contact_roles": [{"id": 1338, "value": 3465}]})
+    result = runner.invoke(
+        app,
+        ["contacts", "add", "person", "--first-name", "John",
+         "--advisor-role", "Associate Advisor:Kadin Bullock", "--more-fields", extra],
+    )
+    assert result.exit_code != 0
+
+
+# ---------------------------------------------------------------------------
+# --advisor-role on update
+# ---------------------------------------------------------------------------
+
+@respx.mock
+def test_update_advisor_role(runner) -> None:
+    respx.get(_ROLES_URL).mock(return_value=httpx.Response(200, json=_ROLES_RESPONSE))
+    route = respx.put("https://api.crmworkspace.com/v1/contacts/10").mock(
+        return_value=httpx.Response(200, json={"id": 10, "name": "John Doe", "type": "Person"})
+    )
+    result = runner.invoke(
+        app,
+        ["contacts", "update", "10", "--advisor-role", "Associate Advisor:Kadin Bullock"],
+    )
+    assert result.exit_code == 0, result.output
+    sent = json.loads(route.calls[0].request.content)
+    assert sent["contact_roles"] == [{"id": 1338, "value": 3465}]
+
+
+def test_update_advisor_role_collides_with_json(runner) -> None:
+    payload = json.dumps({"first_name": "Jon"})
+    result = runner.invoke(
+        app,
+        ["contacts", "update", "10", "--json", payload,
+         "--advisor-role", "Associate Advisor:Kadin Bullock"],
+    )
+    assert result.exit_code != 0


### PR DESCRIPTION
## Why

An agent asked to create a few prospects + set their advisor roles ("Associate Advisor") could not do it through `wbox` and fell back to raw API calls. Root cause: the CLI was **genuinely incapable** of writing contact roles.

`ContactRoleAssignment` was modeled as `{id, type}` with `extra="forbid"`, but the real Wealthbox write shape is `{id, value}` — where `value` is a **role-option id, not a user id**. So even the `--more-fields`/`--json` escape hatches were rejected by validation. There was also no dedicated flag and nothing in the skill docs mapping the firm-required "Second Advisor" to the `contact_roles` mechanism.

## What

- **Fix model:** `ContactRoleAssignment` → `{id: int, value: int}` (the actual API shape).
- **New flag:** repeatable `--advisor-role "Role:User"` on `contacts add person|household|org|trust` and `contacts update`. Resolves the role (by name/id) and user (by name/substring/id) to `{id, value}` via `contacts categories contact-roles`. Guards against collision with a `contact_roles` block in `--more-fields`/`--json`.
- **Docs:** new "Contact Roles" section in `references/contacts.md` (incl. the option-id-vs-user-id nuance), sequential-member-add warning in `references/households.md`, an "exhaust the CLI before raw API" note in `SKILL.md`, refreshed `firm-examples/contacts.md`, regenerated auto-gen flag tables.
- **Tests:** `tests/test_contact_roles.py` — 18 cases (model shape, by-name/id/substring resolution, multi-role, error paths, update, collisions).

## Verification

- `ruff check` clean; full suite **422 passed, 1 skipped**.
- End-to-end against the live API: `wbox contacts update <id> --advisor-role "Associate Advisor:Kadin Bullock"` wrote `{id:1338, value:3465}` correctly.

Version bumped 2.2.1 → **2.3.0** (new feature + bug fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
